### PR TITLE
Keyboard logic rework

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,16 @@
 										></webaudio-switch>
 										<p class="font-inika font-bold self-center">OSC A</p>
 									</div>
+									<div class="flex p-1">
+										<webaudio-switch
+											id="arp_a_switch"
+											class="control"
+											colors="#AB9DF2;#2C292D;#D9D9D9"
+											diameter="30"
+											value="0"
+										></webaudio-switch>
+										<p id="arp_a_label" class="font-inika font-bold ml-1">ARP</p>
+									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
 									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
@@ -525,6 +535,16 @@
 											value="0"
 										></webaudio-switch>
 										<p class="font-inika font-bold self-center">OSC B</p>
+									</div>
+									<div class="flex p-1">
+										<webaudio-switch
+											id="arp_b_switch"
+											class="control"
+											colors="#AB9DF2;#2C292D;#D9D9D9"
+											diameter="30"
+											value="0"
+										></webaudio-switch>
+										<p id="arp_b_label" class="font-inika font-bold ml-1">ARP</p>
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
@@ -822,6 +842,16 @@
 											value="0"
 										></webaudio-switch>
 										<p class="font-inika font-bold self-center">SUB OSC</p>
+									</div>
+									<div class="flex p-1">
+										<webaudio-switch
+											id="arp_c_switch"
+											class="control"
+											colors="#AB9DF2;#2C292D;#D9D9D9"
+											diameter="30"
+											value="0"
+										></webaudio-switch>
+										<p id="arp_c_label" class="font-inika font-bold ml-1">ARP</p>
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
@@ -1239,7 +1269,7 @@
 									diameter="30"
 									value="0"
 								></webaudio-switch>
-								<label class="font-inika font-light self-center" for="lfo_selector">
+								<label class="font-inika font-bold self-center" for="lfo_selector">
 									LFO
 									&nbsp;
 									<select
@@ -1474,11 +1504,83 @@
 				<!-- 	  KEYBOARD 	    -->
 				<!--********************-->
 				<div class="flex justify-center border border-gray-700 p-1 z-10">
-					<div class="w-full">&nbsp;</div>
-					<div class="border border-gray-500 rounded-xl self-center p-2 z-10">
+					<div class="w-full flex justify-between z-10">
+						<div class="flex">
+							<div class="flex flex-col mr-1 z-10">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+									<p class="font-light self-center mb-0.5">Pattern</p>
+									<webaudio-slider
+										id="arp_pattern"
+										class="control mainControl4 self-center"
+										colors="#AB9DF2;#2C292D;#D9D9D9"
+										min="0"
+										max="8"
+										value="0"
+										direction="vert"
+										height="85"
+										conv="['up','down','upDown','downUp','alternateUp','alternateDown','random','randomOnce','randomWalk'][x]"
+									></webaudio-slider>
+									<webaudio-param
+										id="arp_pattern_readout"
+										link="arp_pattern"
+										class="self-center border border-violet-900 mt-1"
+										fontSize="14"
+										width="60"
+									></webaudio-param>
+								</div>
+							</div>
+							<div class="flex flex-col mr-1 z-10">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+									<p class="font-light self-center mb-0.5">Speed</p>
+									<webaudio-slider
+										id="arp_speed"
+										class="control mainControl4 self-center"
+										colors="#AB9DF2;#2C292D;#D9D9D9"
+										min="0"
+										max="6"
+										value="3"
+										direction="vert"
+										height="85"
+										conv="['1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
+									></webaudio-slider>
+									<webaudio-param
+										id="arp_speed_readout"
+										link="arp_speed"
+										class="self-center border border-violet-900 mt-1"
+										fontSize="14"
+										width="60"
+									></webaudio-param>
+								</div>
+							</div>
+						</div>
+						<div class="flex flex-col z-10">
+							<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<p class="font-light self-center mb-0.5">Octave</p>
+								<webaudio-slider
+									id="master_octave"
+									class="control mainControl4 self-center"
+									colors="#FFFFFF;#2C292D;#D9D9D9"
+									min="0"
+									max="4"
+									value="2"
+									direction="vert"
+									height="85"
+									conv="['-2','-1','0','+1','+2'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="master_octave_readout"
+									link="master_octave"
+									class="self-center border border-gray-500 mt-1"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<div class="border border-gray-500 rounded-xl self-center p-2 mx-1 z-10">
 						<webaudio-keyboard
 							id="keyboard"
-							keys="49"
+							keys="65"
 							class="self-center"
 						></webaudio-keyboard>
 					</div>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 			sliderHeight:70,
 		};
 	</script>
-	<script src="src/webaudio-controls.js"></script>
+	<script src="./webaudio-controls.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js" integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js" integrity="sha512-3RlxD1bW34eFKPwj9gUXEWtdSMC59QqIqHnD8O/NoTwSJhgxRizdcFVQhUMFyTp5RwLTDL0Lbcqtl8b7bFAzog==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<title>MS24</title>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 			sliderHeight:70,
 		};
 	</script>
-	<script src="https://g200kg.github.io/webaudio-controls/webaudio-controls.js"></script>
+	<script src="src/webaudio-controls.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js" integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js" integrity="sha512-3RlxD1bW34eFKPwj9gUXEWtdSMC59QqIqHnD8O/NoTwSJhgxRizdcFVQhUMFyTp5RwLTDL0Lbcqtl8b7bFAzog==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<title>MS24</title>

--- a/index.html
+++ b/index.html
@@ -1595,7 +1595,7 @@
 					<div class="border border-gray-500 rounded-xl self-center p-2 mx-1 z-10">
 						<webaudio-keyboard
 							id="keyboard"
-							keys="65"
+							keys="61"
 							class="self-center"
 						></webaudio-keyboard>
 					</div>

--- a/index.html
+++ b/index.html
@@ -183,28 +183,43 @@
 					</div>
 				</div>
 				<div class="w-[250px] flex justify-end">
-					<div class="border border-gray-700 rounded-xl p-1 w-min flex flex-col">
-						<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col">
-							<div class="border border-gray-500 rounded-xl p-1 w-min flex flex-col">
-								<p id="master_gain_label" class="text-center">Master</p>
-								<webaudio-knob
-									id="master_gain"
-									class="control masterControl self-center"
-									colors="#FFFFFF;#2C292D;#D9D9D9"
-									diameter="40"
-									min="0"
-									max="2"
-									value="1"
-									step="0.01"
-								></webaudio-knob>
-								<webaudio-param
-									id="master_gain_readout"
-									link="master_gain"
-									fontSize="14"
-									class="self-center border border-gray-500 mt-1"
-								></webaudio-param>
-							</div>
-						</div>
+					<div class="border border-gray-500 rounded-xl p-1 w-min flex flex-col mr-1">
+						<p id="master_bpm_label" class="text-center">BPM</p>
+						<webaudio-knob
+							id="master_bpm"
+							class="control masterControl self-center"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="40"
+							min="1"
+							max="600"
+							value="120"
+							step="1"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_bpm_readout"
+							link="master_bpm"
+							fontSize="14"
+							class="self-center border border-gray-500 mt-1"
+						></webaudio-param>
+					</div>
+					<div class="border border-gray-500 rounded-xl p-1 w-min flex flex-col">
+						<p id="master_gain_label" class="text-center">Master</p>
+						<webaudio-knob
+							id="master_gain"
+							class="control masterControl self-center"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="40"
+							min="0"
+							max="2"
+							value="1"
+							step="0.01"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_gain_readout"
+							link="master_gain"
+							fontSize="14"
+							class="self-center border border-gray-500 mt-1"
+						></webaudio-param>
 					</div>
 				</div>
 			</div>

--- a/public/webaudio-controls.js
+++ b/public/webaudio-controls.js
@@ -1,3 +1,4 @@
+
 /* *
  *
  *  WebAudio-Controls is based on
@@ -21,6 +22,10 @@
  *	 limitations under the License.
  *
  * */
+
+// EDITED BY: Seán Óg Durack Monks (Mangoshi)
+// EDITS MADE: Keydown logic has been commented-out, as it conflicts with the keydown logic of the main app.
+
 if(window.customElements){
   let styles=document.createElement("style");
   styles.innerHTML=

--- a/src/synth.js
+++ b/src/synth.js
@@ -73,6 +73,7 @@ let PRESET = {
 	MASTER: {
 		gain: 1,
 		octaveOffset: 0,
+		bpm: 120,
 	},
 	OSC_A: {
 		enabled: 1,
@@ -2292,6 +2293,10 @@ for (let i = 0; i < controls.length; i++) {
 				MASTER_GAIN.set({
 					"gain": e.target.value
 				})
+				break;
+			case "master_bpm":
+				PRESET.MASTER.bpm = e.target.value
+				Tone.Transport.bpm.value = e.target.value
 				break;
 			// -------------------- //
 			// --- OSCILLATOR A --- //

--- a/src/synth.js
+++ b/src/synth.js
@@ -1042,10 +1042,6 @@ function startArp(freqA, freqB, freqC) {
 }
 
 function stopArp(freqA, freqB, freqC) {
-	if(freqA && !freqB && !freqC) {
-		freqB = freqA
-		freqC = freqA
-	}
 	if (SYNTH.STATE.arp_A_frequencies.length > 0) {
 		SYNTH.STATE.arp_A_frequencies = SYNTH.STATE.arp_A_frequencies.filter(f => f !== freqA)
 		ARP_A.set({
@@ -1071,40 +1067,67 @@ function stopArp(freqA, freqB, freqC) {
 		ARP_C.stop()
 	}
 	if(SYNTH.STATE.keysHeld === 0) {
-		// Stop all arpeggiators
+		// Empty all arpeggiator frequency arrays
 		SYNTH.STATE.arp_A_frequencies = []
 		SYNTH.STATE.arp_B_frequencies = []
 		SYNTH.STATE.arp_C_frequencies = []
+		// Stop all arpeggiators
 		ARP_A.stop()
 		ARP_B.stop()
 		ARP_C.stop()
 	}
 }
-
+let physicalKeyboardActive = true
+let webaudioControlsReadouts = document.getElementsByTagName("webaudio-param")
+for(let readout of webaudioControlsReadouts){
+	readout.addEventListener("focusin", e => {
+		console.log(e)
+		physicalKeyboardActive = false
+	})
+	readout.addEventListener("focusout", e => {
+		console.log(e)
+		physicalKeyboardActive = true
+	})
+}
+let inputs = document.getElementsByTagName("input")
+for(let input of inputs){
+	input.addEventListener("focusin", e => {
+		console.log(e)
+		physicalKeyboardActive = false
+	})
+	input.addEventListener("focusout", e => {
+		console.log(e)
+		physicalKeyboardActive = true
+	})
+}
 document.addEventListener("keydown", e => {
-	// console.log(e)
-	// If the key is being held down, return
-	if (e.repeat) { return }
-	// Increment keysHeld
-	SYNTH.STATE.keysHeld++
-	console.log("keysHeld (keydown):",SYNTH.STATE.keysHeld)
-	// Prevent default browser behaviour
-	e.preventDefault()
-	// If keysHeld is over 0, handle the note event
-	if (SYNTH.STATE.keysHeld > 0) {
-	handleKeyEvent(e)
+	if(physicalKeyboardActive){
+		// console.log(e)
+		// If the key is being held down, return
+		if (e.repeat) { return }
+		// Increment keysHeld
+		SYNTH.STATE.keysHeld++
+		console.log("keysHeld (keydown):",SYNTH.STATE.keysHeld)
+		// Prevent default browser behaviour
+		// e.preventDefault()
+		// If keysHeld is over 0, handle the note event
+		if (SYNTH.STATE.keysHeld > 0) {
+			handleKeyEvent(e)
+		}
 	}
 })
 document.addEventListener("keyup", e => {
-	// Decrement keysHeld
-	if (SYNTH.STATE.keysHeld > 0){
-		SYNTH.STATE.keysHeld--
+	if(physicalKeyboardActive) {
+		// Decrement keysHeld
+		if (SYNTH.STATE.keysHeld > 0) {
+			SYNTH.STATE.keysHeld--
+		}
+		console.log("keysHeld (keyup):", SYNTH.STATE.keysHeld)
+		// Prevent default browser behaviour
+		// e.preventDefault()
+		// Start the keyboard listener
+		handleKeyEvent(e)
 	}
-	console.log("keysHeld (keyup):",SYNTH.STATE.keysHeld)
-	// Prevent default browser behaviour
-	e.preventDefault()
-	// Start the keyboard listener
-	handleKeyEvent(e)
 })
 
 // Function which listens to the computer keyboard like a MIDI keyboard

--- a/src/synth.js
+++ b/src/synth.js
@@ -44,6 +44,7 @@ Tone.Transport.start()
 
 let SYNTH = {
 	STATE: {
+		physicalKeyboardActive: true,
 		keysHeld: 0,
 		isPlaying: false,
 		playingFrequencies: [],
@@ -256,19 +257,19 @@ let MIN_MAX = {
 // -- DATA CONVERSION -- //
 
 let octaveValues = {
-	"-3": 1,
-	"-2": 2,
-	"-1": 3,
-	"0": 4,
-	"1": 5,
-	"2": 6,
-	"3": 7,
+	"-3": 2,
+	"-2": 3,
+	"-1": 4,
+	"0": 5,
+	"1": 6,
+	"2": 7,
+	"3": 8,
 }
 let subOctaveValues = {
-	"0": 2,
-	"1": 3,
-	"2": 4,
-	"3": 5,
+	"0": 3,
+	"1": 4,
+	"2": 5,
+	"3": 6,
 }
 let oscillatorShapeValues = {
 	"0": "fatsine",
@@ -704,7 +705,7 @@ function resetFX() {
 }
 // TODO: Fix bug where FX params are kept when switching FX, but the GUI doesn't reflect this
 
-// -- NOTES -- //
+// -- ARPEGGIATORS -- //
 
 const ARP_A = new Tone.Pattern(function(time, note){
 	SYNTH_A.triggerAttackRelease(note, "16n", time);
@@ -791,520 +792,8 @@ function connectTone() {
 }
 connectTone()
 
-// -- MIDI -- //
-
-// MIDI Access Class
-class MIDIAccess {
-	constructor(args = {}) {
-		// Either use the passed in function or log to console
-		this.onDeviceInput = args.onDeviceInput || console.log;
-	}
-
-	start() {
-		// Return a promise
-		return new Promise((resolve, reject) => {
-			// Request MIDI Access
-			this._requestAccess().then(access => {
-				// Initialize MIDI Access
-				this.initialize(access);
-				// Resolve the promise
-				resolve();
-			}).catch(() => reject('Something went wrong.'));
-		});
-	}
-
-	initialize(access) {
-		// Get all MIDI inputs
-		const devices = access.inputs.values();
-		// Loop through all MIDI inputs
-		let index = 0
-		for (let device of devices){
-			index++
-			console.log('Device', index)
-			// Initialize the MIDI device
-			this.initializeDevice(device);
-		}
-	}
-
-	initializeDevice(device) {
-		// Listen for MIDI messages
-		device.onmidimessage = this.onMessage.bind(this);
-		// Log the device name, state and type
-		console.log(`Name: ${device.name}\nState: ${device.state}\nType: ${device.type}`)
-	}
-
-	onMessage(message) {
-		// Initialize MIDI data array variables
-		let [command, note, velocity] = message.data;
-		// Run the onDeviceInput function using the MIDI data
-		this.onDeviceInput({ command, note, velocity });
-	}
-
-	_requestAccess() {
-		// Return a promise
-		return new Promise((resolve, reject) => {
-			// Check if the browser supports MIDI
-			if (navigator.requestMIDIAccess)
-				// Request MIDI Access
-				navigator.requestMIDIAccess()
-					.then(resolve)
-					.catch(reject);
-			else reject();
-		});
-	}
-}
-
-// Create a new instance of the MIDIAccess class
-const MIDI = new MIDIAccess({ onDeviceInput })
-
-// Start MIDI Access
-MIDI.start().then(() => {
-	console.log("MIDI Access started")
-}).catch((err) => {
-	console.error(err)
-})
-
-// Handle MIDI Inputs
-function onDeviceInput({command, note, velocity}) {
-	// Log the MIDI data
-	console.log('onDeviceInput', {command, note, velocity})
-	// MIDI command switch
-	switch(command) {
-		// Note On
-		case 144:
-			if (velocity > 0) {
-				handleNote("on", note, velocity)
-			} else {
-				handleNote("off", note)
-			}
-			break;
-		// Note Off
-		case 128:
-			handleNote("off", note)
-			break;
-	}
-}
-
-function midiToFreq(note) {
-	// Return the frequency of a MIDI note
-	return Math.pow(2, (note - 69) / 12) * 440
-}
-
-// function midiGuiActivator(note, state) {
-// 	let gui_state = state === "on" ? 1 : 0
-// 	// Activate the GUI keyboard key of a MIDI note
-// 	switch(note) {
-// 		case 48:
-// 			keyboard.setNote(gui_state, 0, 0)
-// 			break;
-// 		case 49:
-// 			keyboard.setNote(gui_state, 1, 0)
-// 			break;
-// 		case 50:
-// 			keyboard.setNote(gui_state, 2, 0)
-// 			break;
-// 		case 51:
-// 			keyboard.setNote(gui_state, 3, 0)
-// 			break;
-// 		case 52:
-// 			keyboard.setNote(gui_state, 4, 0)
-// 			break;
-// 		case 53:
-// 			keyboard.setNote(gui_state, 5, 0)
-// 			break;
-// 		case 54:
-// 			keyboard.setNote(gui_state, 6, 0)
-// 			break;
-// 		case 55:
-// 			keyboard.setNote(gui_state, 7, 0)
-// 			break;
-// 		case 56:
-// 			keyboard.setNote(gui_state, 8, 0)
-// 			break;
-// 		case 57:
-// 			keyboard.setNote(gui_state, 9, 0)
-// 			break;
-// 		case 58:
-// 			keyboard.setNote(gui_state, 10, 0)
-// 			break;
-// 		case 59:
-// 			keyboard.setNote(gui_state, 11, 0)
-// 			break;
-// 		case 60:
-// 			keyboard.setNote(gui_state, 12, 0)
-// 			break;
-// 		case 61:
-// 			keyboard.setNote(gui_state, 13, 0)
-// 			break;
-// 		case 62:
-// 			keyboard.setNote(gui_state, 14, 0)
-// 			break;
-// 		case 63:
-// 			keyboard.setNote(gui_state, 15, 0)
-// 			break;
-// 		case 64:
-// 			keyboard.setNote(gui_state, 16, 0)
-// 			break;
-// 		case 65:
-// 			keyboard.setNote(gui_state, 17, 0)
-// 			break;
-// 		case 66:
-// 			keyboard.setNote(gui_state, 18, 0)
-// 			break;
-// 		case 67:
-// 			keyboard.setNote(gui_state, 19, 0)
-// 			break;
-// 		case 68:
-// 			keyboard.setNote(gui_state, 20, 0)
-// 			break;
-// 		case 69:
-// 			keyboard.setNote(gui_state, 21, 0)
-// 			break;
-// 		case 70:
-// 			keyboard.setNote(gui_state, 22, 0)
-// 			break;
-// 		case 71:
-// 			keyboard.setNote(gui_state, 23, 0)
-// 			break;
-// 		case 72:
-// 			keyboard.setNote(gui_state, 24, 0)
-// 			break;
-// 		case 73:
-// 			keyboard.setNote(gui_state, 25, 0)
-// 			break;
-// 	}
-// }
-
-// TODO: midiGuiActivator problem
-// midiGuiActivator Problem: The GUI keyboard will only show C4-C6 rather than C0-C8
-// midiGuiActivator Solution: Divide the MIDI note by 12 and round down to get the octave
-// Use current octave as the base octave (start of the keyboard)
-// There are 49 keys in the GUI keyboard, 0-48
-// But no matter what octave the physical keyboard is in, the GUI keyboard should always start at 0
-// keyboard.setNote(gui_state, 0, 0)
-// Additional problem: There's no way to know what octave the physical keyboard is in
-
-// TODO: Fix minor bug where master octave modifier steps up by two octaves each time
-//  - It's due to the octave being determined by the MIDI note / 12
-//  - And having two octaves available on the physical keyboard
-function midiGuiActivator2(note, state) {
-	let gui_state = state === "on" ? 1 : 0
-	// Octave of the note (0 = C0, 1 = C1, 2 = C2, etc.)
-	let octave = Math.floor(note / 12)
-	// Key of the note (0 = C, 1 = C#, 2 = D, etc.)
-	let key = note % 12
-	// Modifier to add to the key to get the GUI key
-	let keyModifier = (PRESET.MASTER.octaveOffset*12)+(octave*12)+24
-	// GUI key
-	let guiKey = key + keyModifier
-	console.log("Octave: " + octave + ", Key: " + key + ", Key Modifier: " + keyModifier + ", GUI Key: " + guiKey)
-	keyboard.setNote(gui_state, guiKey, 0)
-}
-
-function frequencyOffset(octave, semitone) {
-	// Return the frequency offset of an octave and semitone
-	return Math.pow(2, (octave + semitone / 12))
-}
-
-function startArp(freqA, freqB, freqC) {
-	// If ARP A is enabled,
-	if (PRESET.ARP.A_enabled && PRESET.OSC_A.enabled) {
-		// Add the frequency to the array
-		SYNTH.STATE.arp_A_frequencies.push(freqA)
-		// Set Tone Pattern values to the updated array of frequencies
-		ARP_A.set({
-			"values": SYNTH.STATE.arp_A_frequencies,
-		})
-		// If there is only one frequency in the array, start the arp
-		if (SYNTH.STATE.arp_A_frequencies.length === 1) {
-			ARP_A.start()
-		}
-	}
-	// Repeat for ARP B and ARP C
-	if (PRESET.ARP.B_enabled && PRESET.OSC_B.enabled) {
-		SYNTH.STATE.arp_B_frequencies.push(freqB)
-		ARP_B.set({
-			"values": SYNTH.STATE.arp_B_frequencies,
-		})
-		if(SYNTH.STATE.arp_B_frequencies.length === 1) {
-			ARP_B.start()
-		}
-	}
-	if (PRESET.ARP.C_enabled && PRESET.OSC_C.enabled) {
-		SYNTH.STATE.arp_C_frequencies.push(freqC)
-		ARP_C.set({
-			"values": SYNTH.STATE.arp_C_frequencies,
-		})
-		if(SYNTH.STATE.arp_C_frequencies.length === 1) {
-			ARP_C.start()
-		}
-	}
-}
-
-function stopArp(freqA, freqB, freqC) {
-	if (SYNTH.STATE.arp_A_frequencies.length > 0) {
-		SYNTH.STATE.arp_A_frequencies = SYNTH.STATE.arp_A_frequencies.filter(f => f !== freqA)
-		ARP_A.set({
-			"values": SYNTH.STATE.arp_A_frequencies,
-		})
-	}
-	if (SYNTH.STATE.arp_B_frequencies.length > 0) {
-		SYNTH.STATE.arp_B_frequencies = SYNTH.STATE.arp_B_frequencies.filter(f => f !== freqB)
-		ARP_B.set({
-			"values": SYNTH.STATE.arp_B_frequencies,
-		})
-	}
-	if (SYNTH.STATE.arp_C_frequencies.length > 0) {
-		SYNTH.STATE.arp_C_frequencies = SYNTH.STATE.arp_C_frequencies.filter(f => f !== freqC)
-		ARP_C.set({
-			"values": SYNTH.STATE.arp_C_frequencies,
-		})
-	}
-	if(SYNTH.STATE.arp_A_frequencies.length === 0 && SYNTH.STATE.arp_B_frequencies.length === 0 && SYNTH.STATE.arp_C_frequencies.length === 0) {
-		// Stop all arpeggiators
-		ARP_A.stop()
-		ARP_B.stop()
-		ARP_C.stop()
-	}
-	if(SYNTH.STATE.keysHeld === 0) {
-		// Empty all arpeggiator frequency arrays
-		SYNTH.STATE.arp_A_frequencies = []
-		SYNTH.STATE.arp_B_frequencies = []
-		SYNTH.STATE.arp_C_frequencies = []
-		// Stop all arpeggiators
-		ARP_A.stop()
-		ARP_B.stop()
-		ARP_C.stop()
-	}
-}
-let physicalKeyboardActive = true
-let webaudioControlsReadouts = document.getElementsByTagName("webaudio-param")
-for(let readout of webaudioControlsReadouts){
-	readout.addEventListener("focusin", e => {
-		console.log(e)
-		physicalKeyboardActive = false
-	})
-	readout.addEventListener("focusout", e => {
-		console.log(e)
-		physicalKeyboardActive = true
-	})
-}
-let inputs = document.getElementsByTagName("input")
-for(let input of inputs){
-	input.addEventListener("focusin", e => {
-		console.log(e)
-		physicalKeyboardActive = false
-	})
-	input.addEventListener("focusout", e => {
-		console.log(e)
-		physicalKeyboardActive = true
-	})
-}
-document.addEventListener("keydown", e => {
-	if(physicalKeyboardActive){
-		// console.log(e)
-		// If the key is being held down, return
-		if (e.repeat) { return }
-		// Increment keysHeld
-		SYNTH.STATE.keysHeld++
-		console.log("keysHeld (keydown):",SYNTH.STATE.keysHeld)
-		// Prevent default browser behaviour
-		// e.preventDefault()
-		// If keysHeld is over 0, handle the note event
-		if (SYNTH.STATE.keysHeld > 0) {
-			handleKeyEvent(e)
-		}
-	}
-})
-document.addEventListener("keyup", e => {
-	if(physicalKeyboardActive) {
-		// Decrement keysHeld
-		if (SYNTH.STATE.keysHeld > 0) {
-			SYNTH.STATE.keysHeld--
-		}
-		console.log("keysHeld (keyup):", SYNTH.STATE.keysHeld)
-		// Prevent default browser behaviour
-		// e.preventDefault()
-		// Start the keyboard listener
-		handleKeyEvent(e)
-	}
-})
-
-// Function which listens to the computer keyboard like a MIDI keyboard
-// Sending identical MIDI data to the handleNote function
-// The 123456 and QWERTY rows are mapped to the C4-C5 octave
-// The ASDFGH and ZXCVBN rows are mapped to the C3-C4 octave
-function handleKeyEvent(event) {
-	// Log the keydown event
-	console.log('keyboardListener', event)
-	let state = event.type === "keydown" ? "on" : "off"
-	let noteModifier = 0
-	console.log("noteModifier:", noteModifier)
-	// MIDI note switch
-	switch (event.key) {
-		// Top octave
-		case "q":
-			handleNote(state, 12+noteModifier, 127);
-			break;
-		case "2":
-			handleNote(state, 13+noteModifier, 127);
-			break;
-		case "w":
-			handleNote(state, 14+noteModifier, 127);
-			break;
-		case "3":
-			handleNote(state, 15+noteModifier, 127);
-			break;
-		case "e":
-			handleNote(state, 16+noteModifier, 127);
-			break;
-		case "r":
-			handleNote(state, 17+noteModifier, 127);
-			break;
-		case "5":
-			handleNote(state, 18+noteModifier, 127);
-			break;
-		case "t":
-			handleNote(state, 19+noteModifier, 127);
-			break;
-		case "6":
-			handleNote(state, 20+noteModifier, 127);
-			break;
-		case "y":
-			handleNote(state, 21+noteModifier, 127);
-			break;
-		case "7":
-			handleNote(state, 22+noteModifier, 127);
-			break;
-		case "u":
-			handleNote(state, 23+noteModifier, 127);
-			break;
-		case "i":
-			handleNote(state, 24+noteModifier, 127);
-			break;
-		case "9":
-			handleNote(state, 25+noteModifier, 127);
-			break;
-		case "o":
-			handleNote(state, 26+noteModifier, 127);
-			break;
-		case "0":
-			handleNote(state, 27+noteModifier, 127);
-			break;
-		case "p":
-			handleNote(state, 28+noteModifier, 127);
-			break;
-		case "z":
-			handleNote(state, noteModifier, 127)
-			break;
-		case "s":
-			handleNote(state, 1+noteModifier, 127)
-			break;
-		case "x":
-			handleNote(state, 2+noteModifier, 127)
-			break;
-		case "d":
-			handleNote(state, 3+noteModifier, 127)
-			break;
-		case "c":
-			handleNote(state, 4+noteModifier, 127)
-			break;
-		case "v":
-			handleNote(state, 5+noteModifier, 127)
-			break;
-		case "g":
-			handleNote(state, 6+noteModifier, 127)
-			break;
-		case "b":
-			handleNote(state, 7+noteModifier, 127)
-			break;
-		case "h":
-			handleNote(state, 8+noteModifier, 127)
-			break;
-		case "n":
-			handleNote(state, 9+noteModifier, 127)
-			break;
-		case "j":
-			handleNote(state, 10+noteModifier, 127)
-			break;
-		case "m":
-			handleNote(state, 11+noteModifier, 127)
-			break;
-		case ",":
-			handleNote(state, 12+noteModifier, 127)
-			break;
-		default:
-			// Do nothing for other keys
-			break;
-	}
-}
-
-function handleNote(state, note, velocity) {
-	// Log the note data
-	console.log('handleNote', {state, note, velocity})
-	// Optional velocity handling, currently disabled
-	// let velocityScalar = velocity / 127
-	// SYNTH_A.volume.value = Tone.gainToDb(velocityScalar)
-	// SYNTH_B.volume.value = Tone.gainToDb(velocityScalar)
-	// SYNTH_C.volume.value = Tone.gainToDb(velocityScalar)
-	midiGuiActivator2(note, state)
-	// Assigning the frequency of the MIDI note to a variable
-	let originalFrequency = midiToFreq(note)
-	// Pushing the frequency to the array of currently playing frequencies
-	SYNTH.STATE.playingFrequencies.push(originalFrequency)
-	// Calculating the frequency for each oscillator (with octave and detune offsets)
-	let freqA = originalFrequency * frequencyOffset(octaveValues[PRESET.OSC_A.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_A.detune)
-	let freqB = originalFrequency * frequencyOffset(octaveValues[PRESET.OSC_B.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_B.detune)
-	let freqC = originalFrequency * frequencyOffset(subOctaveValues[PRESET.OSC_C.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_C.detune)
-	// If note state is "on"
-	if (state === 'on') {
-		// If any of the oscillators are enabled, set the isPlaying state to true
-		if(PRESET.OSC_A.enabled || PRESET.OSC_B.enabled || PRESET.OSC_C.enabled){
-			SYNTH.STATE.isPlaying = true
-		}
-		// Start the arpeggiator listener
-		startArp(freqA, freqB, freqC)
-
-		if (!PRESET.ARP.A_enabled && PRESET.OSC_A.enabled) {
-			SYNTH_A.triggerAttack(freqA)
-			console.log("OSC A attack", freqA, Tone.Frequency(freqA).toNote())
-		}
-		if (!PRESET.ARP.B_enabled && PRESET.OSC_B.enabled) {
-			SYNTH_B.triggerAttack(freqB)
-			console.log("OSC B attack", freqB, Tone.Frequency(freqB).toNote())
-		}
-		if (!PRESET.ARP.C_enabled && PRESET.OSC_C.enabled) {
-			SYNTH_C.triggerAttack(freqC)
-			console.log("OSC C attack", freqC, Tone.Frequency(freqC).toNote())
-		}
-	} else {
-		SYNTH_A.triggerRelease(freqA)
-		console.log("OSC A release", freqA, Tone.Frequency(freqA).toNote())
-		SYNTH_B.triggerRelease(freqB)
-		console.log("OSC B release", freqB, Tone.Frequency(freqB).toNote())
-		SYNTH_C.triggerRelease(freqC)
-		console.log("OSC C release", freqC, Tone.Frequency(freqC).toNote())
-		// Sometimes a note gets duplicated and this doesn't filter it out
-		SYNTH.STATE.playingFrequencies = SYNTH.STATE.playingFrequencies.filter(f => f !== originalFrequency)
-		// This should fix it
-		if(SYNTH.STATE.playingFrequencies.length === 0) {
-			SYNTH.STATE.isPlaying = false
-			console.log("isPlaying", SYNTH.STATE.isPlaying)
-			SYNTH_A.releaseAll()
-			SYNTH_B.releaseAll()
-			SYNTH_C.releaseAll()
-		}
-		stopArp(freqA, freqB, freqC)
-	}
-	console.log("SYNTH.STATE.playingFrequencies", SYNTH.STATE.playingFrequencies)
-	console.log("ARP.notes_A", SYNTH.STATE.arp_A_frequencies)
-	console.log("ARP.notes_B", SYNTH.STATE.arp_B_frequencies)
-	console.log("ARP.notes_C", SYNTH.STATE.arp_C_frequencies)
-}
-
 // -- GUI CONTROLS -- //
 
-let filterResonanceKnob = document.getElementById("filter_resonance")
 let filterResonanceReadout = document.getElementById("filter_resonance_readout")
 let filterResonanceLabel = document.getElementById("filter_resonance_label")
 let filterResonanceGroup = document.getElementById("filter_resonance_group")
@@ -2048,20 +1537,7 @@ function updatePageColours(pageBackground, synthBackground, text, theme){
 	SYNTH.THEME.synthTextColour = text
 }
 
-// -- MAIN EVENT LISTENERS -- //
-
-// Key-press events //
-document.addEventListener("keypress", function (e) {
-	// console.log(e)
-	// disable quick-find in browser
-	if (e.key === "/") {
-		e.preventDefault()
-	}
-	// disable quick-find (links only) in browser
-	if (e.key === "'") {
-		e.preventDefault()
-	}
-})
+// -- RECORDING -- //
 
 async function startRecording() {
 	// log state of MediaRecorder
@@ -2095,8 +1571,475 @@ async function stopRecording() {
 	}
 }
 
-let arpLabel = document.getElementById("arp_label")
+// -- MIDI LOGIC -- //
 
+// MIDI Access Class
+class MIDIAccess {
+	constructor(args = {}) {
+		// Either use the passed in function or log to console
+		this.onDeviceInput = args.onDeviceInput || console.log;
+	}
+
+	start() {
+		// Return a promise
+		return new Promise((resolve, reject) => {
+			// Request MIDI Access
+			this._requestAccess().then(access => {
+				// Initialize MIDI Access
+				this.initialize(access);
+				// Resolve the promise
+				resolve();
+			}).catch(() => reject('Something went wrong.'));
+		});
+	}
+
+	initialize(access) {
+		// Get all MIDI inputs
+		const devices = access.inputs.values();
+		// Loop through all MIDI inputs
+		let index = 0
+		for (let device of devices){
+			index++
+			console.log('Device', index)
+			// Initialize the MIDI device
+			this.initializeDevice(device);
+		}
+	}
+
+	initializeDevice(device) {
+		// Listen for MIDI messages
+		device.onmidimessage = this.onMessage.bind(this);
+		// Log the device name, state and type
+		console.log(`Name: ${device.name}\nState: ${device.state}\nType: ${device.type}`)
+	}
+
+	onMessage(message) {
+		// Initialize MIDI data array variables
+		let [command, note, velocity] = message.data;
+		// Run the onDeviceInput function using the MIDI data
+		this.onDeviceInput({ command, note, velocity });
+	}
+
+	_requestAccess() {
+		// Return a promise
+		return new Promise((resolve, reject) => {
+			// Check if the browser supports MIDI
+			if (navigator.requestMIDIAccess)
+				// Request MIDI Access
+				navigator.requestMIDIAccess()
+					.then(resolve)
+					.catch(reject);
+			else reject();
+		});
+	}
+}
+
+// Create a new instance of the MIDIAccess class
+const MIDI = new MIDIAccess({ onDeviceInput })
+
+// Start MIDI Access
+MIDI.start().then(() => {
+	console.log("MIDI Access started")
+}).catch((err) => {
+	console.error(err)
+})
+
+// Handle MIDI Inputs
+function onDeviceInput({command, note, velocity}) {
+	// Log the MIDI data
+	console.log('onDeviceInput', {command, note, velocity})
+	// MIDI command switch
+	switch(command) {
+		// Note On
+		case 144:
+			if (velocity > 0) {
+				handleNote("on", note, velocity, "midi")
+			} else {
+				handleNote("off", note, 127,"midi")
+			}
+			break;
+		// Note Off
+		case 128:
+			handleNote("off", note, 127, "midi")
+			break;
+	}
+}
+
+// Get the frequency a MIDI note should trigger
+function midiToFreq(note) {
+	// Return the frequency of a MIDI note
+	return Math.pow(2, (note - 69) / 12) * 440
+}
+
+// Activate a GUI key based on a MIDI note & state
+function guiKeyActivator(note, state) {
+	let gui_state = state === "on" ? 1 : 0
+	// Octave of the note (0 = C0, 1 = C1, 2 = C2, etc.)
+	let octave = Math.floor(note / 12)
+	// Key of the note (0 = C, 1 = C#, 2 = D, etc.)
+	let key = note % 12
+	// Modifier to add to the key to get the GUI key
+	let keyModifier = (octave*12)+24
+	// GUI key
+	let guiKey = key + keyModifier
+	console.log("Octave: " + octave + ", Key: " + key + ", Key Modifier: " + keyModifier + ", GUI Key: " + guiKey)
+	keyboard.setNote(gui_state, guiKey, 0)
+}
+
+// Offset a frequency by an octave and/or semitone
+function frequencyOffset(octave, semitone) {
+	// Return the frequency offset of an octave and semitone
+	return Math.pow(2, (octave + semitone / 12))
+}
+
+// -- ARP LOGIC -- //
+
+function startArp(freqA, freqB, freqC) {
+	// If ARP A is enabled,
+	if (PRESET.ARP.A_enabled && PRESET.OSC_A.enabled) {
+		// Add the frequency to the array
+		SYNTH.STATE.arp_A_frequencies.push(freqA)
+		// Set Tone Pattern values to the updated array of frequencies
+		ARP_A.set({
+			"values": SYNTH.STATE.arp_A_frequencies,
+		})
+		// If there is only one frequency in the array, start the arp
+		if (SYNTH.STATE.arp_A_frequencies.length === 1) {
+			ARP_A.start()
+		}
+	}
+	// Repeat for ARP B and ARP C
+	if (PRESET.ARP.B_enabled && PRESET.OSC_B.enabled) {
+		SYNTH.STATE.arp_B_frequencies.push(freqB)
+		ARP_B.set({
+			"values": SYNTH.STATE.arp_B_frequencies,
+		})
+		if(SYNTH.STATE.arp_B_frequencies.length === 1) {
+			ARP_B.start()
+		}
+	}
+	if (PRESET.ARP.C_enabled && PRESET.OSC_C.enabled) {
+		SYNTH.STATE.arp_C_frequencies.push(freqC)
+		ARP_C.set({
+			"values": SYNTH.STATE.arp_C_frequencies,
+		})
+		if(SYNTH.STATE.arp_C_frequencies.length === 1) {
+			ARP_C.start()
+		}
+	}
+}
+function stopArp(freqA, freqB, freqC) {
+	if (SYNTH.STATE.arp_A_frequencies.length > 0) {
+		SYNTH.STATE.arp_A_frequencies = SYNTH.STATE.arp_A_frequencies.filter(f => f !== freqA)
+		ARP_A.set({
+			"values": SYNTH.STATE.arp_A_frequencies,
+		})
+	}
+	if (SYNTH.STATE.arp_B_frequencies.length > 0) {
+		SYNTH.STATE.arp_B_frequencies = SYNTH.STATE.arp_B_frequencies.filter(f => f !== freqB)
+		ARP_B.set({
+			"values": SYNTH.STATE.arp_B_frequencies,
+		})
+	}
+	if (SYNTH.STATE.arp_C_frequencies.length > 0) {
+		SYNTH.STATE.arp_C_frequencies = SYNTH.STATE.arp_C_frequencies.filter(f => f !== freqC)
+		ARP_C.set({
+			"values": SYNTH.STATE.arp_C_frequencies,
+		})
+	}
+	if(SYNTH.STATE.arp_A_frequencies.length === 0 && SYNTH.STATE.arp_B_frequencies.length === 0 && SYNTH.STATE.arp_C_frequencies.length === 0) {
+		// Stop all arpeggiators
+		ARP_A.stop()
+		ARP_B.stop()
+		ARP_C.stop()
+	}
+	if(SYNTH.STATE.keysHeld === 0) {
+		// Empty all arpeggiator frequency arrays
+		SYNTH.STATE.arp_A_frequencies = []
+		SYNTH.STATE.arp_B_frequencies = []
+		SYNTH.STATE.arp_C_frequencies = []
+		// Stop all arpeggiators
+		ARP_A.stop()
+		ARP_B.stop()
+		ARP_C.stop()
+	}
+}
+
+// -- KEYBOARD LOGIC -- //
+
+let webaudioControlsReadouts = document.getElementsByTagName("webaudio-param")
+for(let readout of webaudioControlsReadouts){
+	readout.addEventListener("focusin", e => {
+		console.log(e)
+		SYNTH.STATE.physicalKeyboardActive = false
+	})
+	readout.addEventListener("focusout", e => {
+		console.log(e)
+		SYNTH.STATE.physicalKeyboardActive = true
+	})
+}
+let inputs = document.getElementsByTagName("input")
+for(let input of inputs) {
+	input.addEventListener("focusin", e => {
+		console.log(e)
+		SYNTH.STATE.physicalKeyboardActive = false
+	})
+	input.addEventListener("focusout", e => {
+		console.log(e)
+		SYNTH.STATE.physicalKeyboardActive = true
+	})
+}
+
+// Handle any note events (MIDI, keyboard, or mouse)
+function handleNote(state, note, velocity, origin) {
+	// Log the note data
+	console.log('handleNote', {state, note, velocity})
+	// Optional velocity handling, currently disabled
+	// let velocityScalar = velocity / 127
+	// SYNTH_A.volume.value = Tone.gainToDb(velocityScalar)
+	// SYNTH_B.volume.value = Tone.gainToDb(velocityScalar)
+	// SYNTH_C.volume.value = Tone.gainToDb(velocityScalar)
+	// If the note is a MIDI note, subtract 48 to get the correct frequency
+	note = origin === 'midi' ? note - 48 : note
+	// console.log("note:",note)
+	// If the origin is not the mouse, activate a GUI key
+	if(origin !== "mouse"){
+		guiKeyActivator(note, state)
+	}
+	// Initialize the original frequency with midiToFreq
+	let originalFrequency = midiToFreq(note)
+	// Push the frequency to the array of currently playing frequencies
+	SYNTH.STATE.playingFrequencies.push(originalFrequency)
+	// Calculate the frequency for each oscillator (with octave and detune offsets)
+	let freqA = originalFrequency * frequencyOffset(octaveValues[PRESET.OSC_A.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_A.detune)
+	let freqB = originalFrequency * frequencyOffset(octaveValues[PRESET.OSC_B.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_B.detune)
+	let freqC = originalFrequency * frequencyOffset(subOctaveValues[PRESET.OSC_C.octave]+PRESET.MASTER.octaveOffset, PRESET.OSC_C.detune)
+	// If note state is "on"
+	if (state === 'on') {
+		// If any of the oscillators are enabled, set the isPlaying state to true
+		if(PRESET.OSC_A.enabled || PRESET.OSC_B.enabled || PRESET.OSC_C.enabled){
+			SYNTH.STATE.isPlaying = true
+		}
+		// Start the arpeggiator listener
+		startArp(freqA, freqB, freqC)
+
+		// If the arpeggiator is not enabled for an enabled oscillator,
+		// trigger the attack for that oscillator with the calculated frequency
+		if (!PRESET.ARP.A_enabled && PRESET.OSC_A.enabled) {
+			SYNTH_A.triggerAttack(freqA)
+			console.log("OSC A attack", freqA, Tone.Frequency(freqA).toNote())
+		}
+		if (!PRESET.ARP.B_enabled && PRESET.OSC_B.enabled) {
+			SYNTH_B.triggerAttack(freqB)
+			console.log("OSC B attack", freqB, Tone.Frequency(freqB).toNote())
+		}
+		if (!PRESET.ARP.C_enabled && PRESET.OSC_C.enabled) {
+			SYNTH_C.triggerAttack(freqC)
+			console.log("OSC C attack", freqC, Tone.Frequency(freqC).toNote())
+		}
+		// If note state is "off"
+	} else {
+		// Release the note for each oscillator
+		SYNTH_A.triggerRelease(freqA)
+		console.log("OSC A release", freqA, Tone.Frequency(freqA).toNote())
+		SYNTH_B.triggerRelease(freqB)
+		console.log("OSC B release", freqB, Tone.Frequency(freqB).toNote())
+		SYNTH_C.triggerRelease(freqC)
+		console.log("OSC C release", freqC, Tone.Frequency(freqC).toNote())
+		// Sometimes a note gets duplicated and this doesn't always filter it out
+		SYNTH.STATE.playingFrequencies = SYNTH.STATE.playingFrequencies.filter(f => f !== originalFrequency)
+		// This should fix it
+		// TODO: Figure out why this is happening
+		if(SYNTH.STATE.playingFrequencies.length === 0) {
+			SYNTH.STATE.isPlaying = false
+			console.log("isPlaying", SYNTH.STATE.isPlaying)
+			SYNTH_A.releaseAll()
+			SYNTH_B.releaseAll()
+			SYNTH_C.releaseAll()
+		}
+		// Stop the arpeggiators
+		stopArp(freqA, freqB, freqC)
+	}
+	// Log the currently playing frequencies
+	console.log("SYNTH.STATE.playingFrequencies", SYNTH.STATE.playingFrequencies)
+	// Log the arpeggiator frequency array, if enabled
+	if(PRESET.ARP.A_enabled && PRESET.OSC_A.enabled){
+		console.log("ARP.notes_A", SYNTH.STATE.arp_A_frequencies)
+	}
+	if(PRESET.ARP.B_enabled && PRESET.OSC_B.enabled){
+		console.log("ARP.notes_B", SYNTH.STATE.arp_B_frequencies)
+	}
+	if(PRESET.ARP.C_enabled && PRESET.OSC_C.enabled){
+		console.log("ARP.notes_C", SYNTH.STATE.arp_C_frequencies)
+	}
+}
+
+// Function which listens to the computer keyboard like a MIDI keyboard
+// Sending identical MIDI data to the handleNote function
+// The 123456 and QWERTY rows are mapped to the C4-C5 octave
+// The ASDFGH and ZXCVBN rows are mapped to the C3-C4 octave
+function handleKeyEvent(event) {
+	// Log the keydown event
+	console.log('keyboardListener', event)
+	let state = event.type === "keydown" ? "on" : "off"
+	// MIDI note switch
+	switch (event.key) {
+		// Bottom octave (C3-C4)
+		case "z":
+			handleNote(state, 0, 127)
+			break;
+		case "s":
+			handleNote(state, 1, 127)
+			break;
+		case "x":
+			handleNote(state, 2, 127)
+			break;
+		case "d":
+			handleNote(state, 3, 127)
+			break;
+		case "c":
+			handleNote(state, 4, 127)
+			break;
+		case "v":
+			handleNote(state, 5, 127)
+			break;
+		case "g":
+			handleNote(state, 6, 127)
+			break;
+		case "b":
+			handleNote(state, 7, 127)
+			break;
+		case "h":
+			handleNote(state, 8, 127)
+			break;
+		case "n":
+			handleNote(state, 9, 127)
+			break;
+		case "j":
+			handleNote(state, 10, 127)
+			break;
+		case "m":
+			handleNote(state, 11, 127)
+			break;
+		case ",":
+			handleNote(state, 12, 127)
+			break;
+		// Top octave (C4-C5)
+		case "q":
+			handleNote(state, 12, 127);
+			break;
+		case "2":
+			handleNote(state, 13, 127);
+			break;
+		case "w":
+			handleNote(state, 14, 127);
+			break;
+		case "3":
+			handleNote(state, 15, 127);
+			break;
+		case "e":
+			handleNote(state, 16, 127);
+			break;
+		case "r":
+			handleNote(state, 17, 127);
+			break;
+		case "5":
+			handleNote(state, 18, 127);
+			break;
+		case "t":
+			handleNote(state, 19, 127);
+			break;
+		case "6":
+			handleNote(state, 20, 127);
+			break;
+		case "y":
+			handleNote(state, 21, 127);
+			break;
+		case "7":
+			handleNote(state, 22, 127);
+			break;
+		case "u":
+			handleNote(state, 23, 127);
+			break;
+		case "i":
+			handleNote(state, 24, 127);
+			break;
+		case "9":
+			handleNote(state, 25, 127);
+			break;
+		case "o":
+			handleNote(state, 26, 127);
+			break;
+		case "0":
+			handleNote(state, 27, 127);
+			break;
+		case "p":
+			handleNote(state, 28, 127);
+			break;
+		default:
+			// Do nothing for other keys
+			break;
+	}
+}
+
+// Keypress listener to disable quick-find in browser
+document.addEventListener("keypress", function (e) {
+	// console.log(e)
+	// disable quick-find in browser
+	if (e.key === "/") {
+		e.preventDefault()
+	}
+	// disable quick-find (links only) in browser
+	if (e.key === "'") {
+		e.preventDefault()
+	}
+})
+
+// Keydown listener to handle computer keyboard events (on)
+document.addEventListener("keydown", e => {
+	// If the physical keyboard is active (not disabled by focused input box)
+	if(SYNTH.STATE.physicalKeyboardActive){
+		// If the key is being held down, return
+		// (This prevents the keydown event from firing multiple times)
+		if (e.repeat) { return }
+		// Increment keysHeld
+		SYNTH.STATE.keysHeld++
+		// Log the number of keys held on keydown
+		console.log("keysHeld (keydown):",SYNTH.STATE.keysHeld)
+		// If keysHeld is over 0, handle the note event
+		if (SYNTH.STATE.keysHeld > 0) {
+			handleKeyEvent(e)
+		}
+	}
+})
+
+// Keyup listener to handle computer keyboard events (off)
+document.addEventListener("keyup", e => {
+	// Decrement keysHeld if it is over 0
+	// (This prevents bug where keysHeld can become negative)
+	if (SYNTH.STATE.keysHeld > 0) {
+		SYNTH.STATE.keysHeld--
+	}
+	// Log the number of keys held on keyup
+	console.log("keysHeld (keyup):", SYNTH.STATE.keysHeld)
+	// Handle the note event
+	handleKeyEvent(e)
+})
+
+// Virtual (GUI) keyboard
+let keyboard = document.getElementById("keyboard");
+
+// Event listener for the virtual (GUI) keyboard
+keyboard.addEventListener("change", function (e) {
+	// Handle note event
+	// e.note[0] is the note state (on/off)
+	// e.note[1] is the note number (0-127)
+	// Subtracting 24 to align the octave with the other input methods
+	handleNote(e.note[0] ? "on" : "off", e.note[1]-24, 127, "mouse")
+});
+
+// Function which changes note values on the fly
+// Allowing for octave/detune offsets to work while the synth is playing
 function changeNote(targetSynth, targetValue, newValue){
 	// Original value + offset
 	// If octave/detune knob, then its octave/detune + master octave offset
@@ -2195,7 +2138,7 @@ function changeNote(targetSynth, targetValue, newValue){
 				targetSynth.triggerAttack(offsetFrequency)
 			}
 		}
-	// If synth is not playing when control is changed
+		// If synth is not playing when control is changed
 	} else {
 		// Log old value
 		console.log("old value:", targetSynthName, targetOscillator[targetValue])
@@ -2212,14 +2155,14 @@ function changeNote(targetSynth, targetValue, newValue){
 	}
 	switch(targetSynth) {
 		case SYNTH_A:
-		SYNTH.STATE.arp_A_frequencies = targetArpeggiatorNotes
-		break;
+			SYNTH.STATE.arp_A_frequencies = targetArpeggiatorNotes
+			break;
 		case SYNTH_B:
-		SYNTH.STATE.arp_B_frequencies = targetArpeggiatorNotes
-		break;
+			SYNTH.STATE.arp_B_frequencies = targetArpeggiatorNotes
+			break;
 		case SYNTH_C:
-		SYNTH.STATE.arp_C_frequencies = targetArpeggiatorNotes
-		break;
+			SYNTH.STATE.arp_C_frequencies = targetArpeggiatorNotes
+			break;
 	}
 	console.log("changeNote from:", targetValue+"_"+targetSynthName, targetOscillator[targetValue] ? targetOscillator[targetValue] : PRESET.MASTER.octaveOffset, "NEW:", newValue)
 	console.log("ARP.notes_A", SYNTH.STATE.arp_A_frequencies)
@@ -2227,15 +2170,18 @@ function changeNote(targetSynth, targetValue, newValue){
 	console.log("ARP.notes_C", SYNTH.STATE.arp_C_frequencies)
 }
 
+// -- GUI CONTROLS LOGIC -- //
+
 let controls = document.getElementsByClassName("control");
 // console.log(controls);
 
-// Control events //
+// For each control...
 for (let i = 0; i < controls.length; i++) {
-	// -- TOGGLE CONTROLS -- //
+	// ...add a "change" event listener
 	controls[i].addEventListener("change", async function (e) {
-		// log the control and its value
+		// Log the event target ID and its value
 		console.log(e.target.id, e.target.value)
+		// Switch case for each control
 		switch (e.target.id) {
 			case "osc_a_switch":
 				PRESET.OSC_A.enabled = e.target.value
@@ -2823,141 +2769,6 @@ for (let i = 0; i < controls.length; i++) {
 		}
 	})
 }
-
-// -- KEYBOARD LOGIC -- //
-
-let keyboard = document.getElementById("keyboard");
-
-function getNoteFromNumber(number, semitoneOffset, octaveOffset) {
-	const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-	let adjustedNumber = (number + semitoneOffset) % 12;
-	if (adjustedNumber < 0) {
-		adjustedNumber += 12;
-	}
-	const noteIndex = (notes.indexOf('C') + adjustedNumber) % 12;
-	let octave = Math.floor((number + semitoneOffset) / 12) + octaveOffset;
-	if (adjustedNumber < 0) {
-		octave -= 1;
-	}
-	return notes[noteIndex] + octave;
-}
-
-// If keyboard change listener is triggered, send notes to array in outer scope
-// If notes exist in the array, trigger them.
-// If notes don't exist in the array, release them?
-// If controls are updated, update the array, trigger the new notes, release old ones
-
-// TODO: Attempt incorporating the function below, note calc + trigger outside of change EL
-
-// function triggerNoteTest(number, semitoneOffset, octaveOffset) {
-// 	const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-// 	let adjustedNumber = (number + semitoneOffset) % 12;
-// 	if (adjustedNumber < 0) {
-// 		adjustedNumber += 12;
-// 	}
-// 	const noteIndex = (notes.indexOf('C') + adjustedNumber) % 12;
-// 	let octave = Math.floor((number + semitoneOffset) / 12) + octaveOffset;
-// 	if (adjustedNumber < 0) {
-// 		octave -= 1;
-// 	}
-// 	SYNTH_A.releaseAll()
-// 	SYNTH_A.triggerAttack(notes[noteIndex] + octave, "8n")
-// }
-
-keyboard.addEventListener("mouseover", function () {
-	// Focus on keyboard element so it activates physical keyboard input
-	keyboard.cv.focus();
-	console.log("mouse over keyboard!");
-});
-
-let heldKeys = [];
-let playingKeys = [];
-
-keyboard.addEventListener("change", function (e) {
-	// Calculate the notes to play based on the keyboard input and synth settings
-	let note_a = getNoteFromNumber(e.note[1], PRESET.OSC_A.detune, octaveValues[PRESET.OSC_A.octave]);
-	let note_b = getNoteFromNumber(e.note[1], PRESET.OSC_B.detune, octaveValues[PRESET.OSC_B.octave]);
-	let note_c = getNoteFromNumber(e.note[1], PRESET.OSC_C.detune, subOctaveValues[PRESET.OSC_C.octave]);
-
-	// console.log(e.note)
-
-	console.log("note_a", note_a, e.note[0] ? "on" : "off");
-	console.log("note_b", note_b, e.note[0] ? "on" : "off");
-	console.log("note_c", note_c, e.note[0] ? "on" : "off");
-
-	// Initialize an empty array to keep track of the currently playing keys
-
-	// TODO: Figure out playingKeys / heldKeys logic
-	//  playingKeys: you can change note parameters while playing keys,
-	//    but playing new keys overwrites playingKeys,
-	//    so when you release the last set of keys, it kills all keys...
-	//  heldKeys: changing note parameters while playing keys will cause keys to stick,
-	//    but you can let go of keys without all keys being released...
-
-
-	// If note on
-	if (e.note[0]) {
-		// if not already in heldKeys array, push it
-		if (!heldKeys.includes(note_a+"_OSC_A") || !heldKeys.includes(note_b+"_OSC_B") || !heldKeys.includes(note_c+"_OSC_C")) {
-			// LFO.stop()
-			heldKeys.push(note_a+"_OSC_A");
-			heldKeys.push(note_b+"_OSC_B");
-			heldKeys.push(note_c+"_OSC_C");
-			// Trigger the attack for the new notes and add them to the playingKeys array
-
-			// Start the arpeggiator listener
-			startArp(note_a, note_b, note_c)
-
-			SYNTH_A.triggerAttack(note_a);
-			playingKeys.push(note_a+"_OSC_A");
-			console.log("OSC_A Frequency:", SYNTH_A.toFrequency(note_a))
-
-			SYNTH_B.triggerAttack(note_b);
-			playingKeys.push(note_b+"_OSC_B");
-			console.log("OSC_B Frequency:", SYNTH_B.toFrequency(note_b))
-
-			SYNTH_C.triggerAttack(note_c);
-			playingKeys.push(note_c+"_OSC_C");
-			console.log("OSC_C Frequency:", SYNTH_C.toFrequency(note_c))
-
-			console.log("playingKeys:", playingKeys)
-			console.log("heldKeys:", heldKeys)
-			// LFO.start()
-		}
-		// If note off
-	} else {
-		stopArp(note_a, note_b, note_c)
-		// remove the note from the heldKeys array
-		heldKeys = heldKeys.filter(item => item !== note_a+"_OSC_A" && item !== note_b+"_OSC_B" && item !== note_c+"_OSC_C");
-		if (playingKeys.includes(note_a+"_OSC_A") || playingKeys.includes(note_b+"_OSC_B") || playingKeys.includes(note_c+"_OSC_C")) {
-			SYNTH.STATE.isPlaying = true;
-		}
-		// Trigger the release for the playing notes and remove them from the playingKeys array
-		if (playingKeys.includes(note_a+"_OSC_A")) {
-			SYNTH_A.triggerRelease(note_a);
-			playingKeys = playingKeys.filter(item => item !== note_a+"_OSC_A");
-		}
-		if (playingKeys.includes(note_b+"_OSC_B")) {
-			SYNTH_B.triggerRelease(note_b);
-			playingKeys = playingKeys.filter(item => item !== note_b+"_OSC_B");
-		}
-		if (playingKeys.includes(note_c+"_OSC_C")) {
-			SYNTH_C.triggerRelease(note_c);
-			playingKeys = playingKeys.filter(item => item !== note_c+"_OSC_C");
-		}
-		console.log("playingKeys:", playingKeys)
-		console.log("heldKeys:", heldKeys)
-		if (playingKeys.length === 0) {
-			// Stop all playing notes when no keys are held down
-			SYNTH_A.releaseAll();
-			SYNTH_B.releaseAll();
-			SYNTH_C.releaseAll();
-			console.log("released all!");
-			SYNTH.STATE.isPlaying = false;
-		}
-		// LFO.stop()
-	}
-});
 
 // -- CANVAS SETUP -- //
 

--- a/src/synth.js
+++ b/src/synth.js
@@ -14,22 +14,15 @@ await register(await connect())
 	.catch((err) => {console.error(err)})
 
 // TODO:
-//  1. LFO SWITCHING
-//  2. PHRASE RECORDER (Arpeggiator Latch)
-//  3. GLIDE CONTROLS (Portamento)
-//  4. TOOLTIPS / HELP TEXT
-//  5. RANDOMIZE PRESET
-//  6. MISSING VISUALIZATIONS (FILTER, LFO, FX)
-
-// TODO: BUG FIXES
-//  1. REVERB LOAD ???
-//  2. DOUBLE NOTES !!!
-//  3. ARP PRESET LOGIC !!!
+//  1. TOOLTIPS / HELP TEXT
+//  2. RANDOMIZE PRESET
+//  4. MISSING VISUALIZATIONS (FILTER, LFO, FX)
+//  5. PHRASE RECORDER? (Arpeggiator Latch)
+//  6. FIX LFO SWITCHING
+//  7. DISPLAY REVERB LOAD (If possible)
 
 // TODO: BONUS SYNTH FEATURES
-//  ✔ Unison/Spread (Requires "fat" oscillator types)
 //  - Glide (Figure out why it's not working)
-//  ✔ FM (Requires FMSynth) (Can combine with fat oscillator types)
 //  - Partials control (Will require strange dynamic controls for each partial)
 //  - FX Buses (Will require using Tone.Channel: send generators to bus and receive on FX)
 //  - Noise Generators (Will require using Tone.Noise)
@@ -1902,8 +1895,8 @@ function handleNote(state, note, velocity, origin) {
 			console.log("OSC C release", freqC, Tone.Frequency(freqC).toNote())
 			// Sometimes a note gets duplicated and this doesn't always filter it out
 			SYNTH.STATE.playingFrequencies = SYNTH.STATE.playingFrequencies.filter(f => f !== originalFrequency)
-			// This should fix it
-			// TODO: Figure out why this is happening
+			// This doesn't fix it, but it's still a useful safeguard
+			// The actual issue is bypassed in the keydown event handler below
 			if (SYNTH.STATE.playingFrequencies.length === 0) {
 				SYNTH.STATE.isPlaying = false
 				console.log("isPlaying", SYNTH.STATE.isPlaying)
@@ -2310,6 +2303,8 @@ for (let i = 0; i < controls.length; i++) {
 				}
 				break;
 			case "arp_a_switch":
+				// TODO: BUG: If octave is changed while arp is off,
+				//  and then arp is turned on, the arp will play the old octave
 				PRESET.ARP.A_enabled = e.target.value
 				if(e.target.value === 0){
 					ARP_A.stop()

--- a/src/webaudio-controls.js
+++ b/src/webaudio-controls.js
@@ -1,0 +1,1990 @@
+/* *
+ *
+ *  WebAudio-Controls is based on
+ *    webaudio-knob by Eiji Kitamura http://google.com/+agektmr
+ *    webaudio-slider by RYoya Kawai https://plus.google.com/108242669191458983485/posts
+ *    webaudio-switch by Keisuke Ai http://d.hatena.ne.jp/aike/
+ *  Integrated and enhanced by g200kg http://www.g200kg.com/
+ *
+ *	Copyright 2013 Eiji Kitamura / Ryoya KAWAI / Keisuke Ai / g200kg(Tatsuya Shinyagaito)
+ *
+ *	 Licensed under the Apache License, Version 2.0 (the "License");
+ *	 you may not use this file except in compliance with the License.
+ *	 You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	 Unless required by applicable law or agreed to in writing, software
+ *	 distributed under the License is distributed on an "AS IS" BASIS,
+ *	 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	 See the License for the specific language governing permissions and
+ *	 limitations under the License.
+ *
+ * */
+if(window.customElements){
+  let styles=document.createElement("style");
+  styles.innerHTML=
+`#webaudioctrl-context-menu {
+  display: none;
+  position: absolute;
+  z-index: 10;
+  padding: 0;
+  width: 100px;
+  color:#eee;
+  background-color: #268;
+  border: solid 1px #888;
+  box-shadow: 1px 1px 2px #888;
+  font-family: sans-serif;
+  font-size: 11px;
+  line-height:1.7em;
+  text-align:center;
+  cursor:pointer;
+  color:#fff;
+  list-style: none;
+}
+#webaudioctrl-context-menu.active {
+  display: block;
+}
+.webaudioctrl-context-menu__item {
+  display: block;
+  margin: 0;
+  padding: 0;
+  color: #000;
+  background-color:#eee;
+  text-decoration: none;
+}
+.webaudioctrl-context-menu__title{
+  font-weight:bold;
+}
+.webaudioctrl-context-menu__item:last-child {
+  margin-bottom: 0;
+}
+.webaudioctrl-context-menu__item:hover {
+  background-color: #b8b8b8;
+}
+`;
+  document.head.appendChild(styles);
+  let midimenu=document.createElement("ul");
+  midimenu.id="webaudioctrl-context-menu";
+  midimenu.innerHTML=
+`<li class="webaudioctrl-context-menu__title">MIDI Learn</li>
+<li class="webaudioctrl-context-menu__item" id="webaudioctrl-context-menu-learn" onclick="webAudioControlsWidgetManager.contextMenuLearn()">Learn</li>
+<li class="webaudioctrl-context-menu__item" onclick="webAudioControlsWidgetManager.contextMenuClear()">Clear</li>
+<li class="webaudioctrl-context-menu__item" onclick="webAudioControlsWidgetManager.contextMenuClose()">Close</li>
+`;
+  let opt={
+    useMidi:0,
+    preserveMidiLearn:0,
+    preserveValue:0,
+    midilearn:0,
+    mididump:0,
+    outline:null,
+    knobSrc:null,
+    knobSprites:null,
+    knobWidth:null,
+    knobHeight:null,
+    knobDiameter:null,
+    knobColors:"#e00;#000;#fff",
+    sliderSrc:null,
+    sliderWidth:null,
+    sliderHeight:null,
+    sliderKnobSrc:null,
+    sliderKnobWidth:null,
+    sliderKnobHeight:null,
+    sliderDitchlength:null,
+    sliderColors:"#e00;#333;#fcc",
+    switchWidth:null,
+    switchHeight:null,
+    switchDiameter:null,
+    switchColors:"#e00;#000;#fcc",
+    paramWidth:null,
+    paramHeight:null,
+    paramFontSize:9,
+    paramColors:"#fff;#000",
+    valuetip:0,
+    xypadColors:"#e00;#000;#fcc",
+  };
+  if(window.WebAudioControlsOptions)
+    Object.assign(opt,window.WebAudioControlsOptions);
+  class WebAudioControlsWidget extends HTMLElement{
+    constructor(){
+      super();
+      this.addEventListener("keydown",this.keydown);
+      this.addEventListener("mousedown",this.pointerdown,{passive:false});
+      this.addEventListener("touchstart",this.pointerdown,{passive:false});
+      this.addEventListener("wheel",this.wheel,{passive:false});
+      this.addEventListener("mouseover",this.pointerover);
+      this.addEventListener("mouseout",this.pointerout);
+      this.addEventListener("contextmenu",this.contextMenu);
+      this.hover=this.drag=0;
+      document.body.appendChild(midimenu);
+      this.basestyle=`
+.webaudioctrl-tooltip{
+  display:inline-block;
+  position:absolute;
+  margin:0 -1000px;
+  z-index: 999;
+  background:#eee;
+  color:#000;
+  border:1px solid #666;
+  border-radius:4px;
+  padding:5px 10px;
+  text-align:center;
+  left:0; top:0;
+  font-size:11px;
+  opacity:0;
+  visibility:hidden;
+}
+.webaudioctrl-tooltip:before{
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -8px;
+  border: 8px solid transparent;
+  border-top: 8px solid #666;
+}
+.webaudioctrl-tooltip:after{
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -6px;
+  border: 6px solid transparent;
+  border-top: 6px solid #eee;
+}
+`;
+      this.onblur=()=>{
+        this.elem.style.outline="none";
+      }
+      this.onfocus=()=>{
+        switch(+this.outline){
+        case null:
+        case 0:
+          this.elem.style.outline="none";
+          break;
+        case 1:
+          this.elem.style.outline="1px solid #444";
+          break;
+        default:
+          this.elem.style.outline=this.outline;
+        }
+      }
+    }
+    sendEvent(ev){
+      let event;
+      event=document.createEvent("HTMLEvents");
+      event.initEvent(ev,false,true);
+      this.dispatchEvent(event);
+    }
+    getAttr(n,def){
+      let v=this.getAttribute(n);
+      if(v==null) return def;
+      switch(typeof(def)){
+      case "number":
+        if(v=="true") return 1;
+        v=+v;
+        if(isNaN(v)) return 0;
+        return v;
+      }
+      return v;
+    }
+    showtip(d){
+      function valstr(x,c,type){
+        switch(type){
+        case "x": return (x|0).toString(16);
+        case "X": return (x|0).toString(16).toUpperCase();
+        case "d": return (x|0).toString();
+        case "f": return parseFloat(x).toFixed(c);
+        case "s": return x.toString();
+        }
+        return "";
+      }
+      function numformat(s,x){
+        let i=s.indexOf("%");
+        let j=i+1;
+        if(i<0)
+          j=s.length;
+        let c=[0,0],type=0,m=0,r="";
+        if(s.indexOf("%s")>=0){
+          return s.replace("%s",x);
+        }
+        for(;j<s.length;++j){
+          if("dfxXs".indexOf(s[j])>=0){
+            type=s[j];
+            break;
+          }
+          if(s[j]==".")
+            m=1;
+          else
+            c[m]=c[m]*10+parseInt(s[j]);
+        }
+        r=valstr(x,c[1],type);
+        if(c[0]>0)
+          r=("               "+r).slice(-c[0]);
+        r=s.replace(/%.*[xXdfs]/,r);
+        return r;
+      }
+      let s=this.tooltip;
+      if(this.drag||this.hover){
+        if(this.valuetip){
+          if(s==null)
+            s=`%s`;
+          else if(s.indexOf("%")<0)
+            s+=` : %s`;
+        }
+        if(s){
+          this.ttframe.innerHTML=numformat(s,this.convValue);
+          this.ttframe.style.display="inline-block";
+          this.ttframe.style.width="auto";
+          this.ttframe.style.height="auto";
+          this.ttframe.style.transition="opacity 0.5s "+d+"s,visibility 0.5s "+d+"s";
+          this.ttframe.style.opacity=0.9;
+          this.ttframe.style.visibility="visible";
+          let rc=this.getBoundingClientRect(),rc2=this.ttframe.getBoundingClientRect(),rc3=document.documentElement.getBoundingClientRect();
+          this.ttframe.style.left=((rc.width-rc2.width)*0.5+1000)+"px";
+          this.ttframe.style.top=(-rc2.height-8)+"px";
+          return;
+        }
+      }
+      this.ttframe.style.transition="opacity 0.1s "+d+"s,visibility 0.1s "+d+"s";
+      this.ttframe.style.opacity=0;
+      this.ttframe.style.visibility="hidden";
+    }
+    setupLabel(){
+      this.labelpos=this.getAttr("labelpos", "bottom 0px");
+      const lpos=this.labelpos.split(" ");
+      let offs="";
+      if(lpos.length==3)
+        offs=`translate(${lpos[1]},${lpos[2]})`;
+      this.label.style.position="absolute";
+      switch(lpos[0]){
+      case "center":
+        this.label.style.top="50%";
+        this.label.style.left="50%";
+        this.label.style.transform=`translate(-50%,-50%) ${offs}`;
+        break;
+      case "right":
+        this.label.style.top="50%";
+        this.label.style.left="100%";
+        this.label.style.transform=`translateY(-50%) ${offs}`;
+        break;
+      case "left":
+        this.label.style.top="50%";
+        this.label.style.left="0%";
+        this.label.style.transform=`translate(-100%,-50%) ${offs}`;
+        break;
+      case "bottom":
+        this.label.style.top="100%";
+        this.label.style.left="50%";
+        this.label.style.transform=`translateX(-50%) ${offs}`;
+        break;
+      case "top":
+        this.label.style.top="0%";
+        this.label.style.left="50%";
+        this.label.style.transform=`translate(-50%,-100%) ${offs}`;
+        break;
+      }
+    }
+    pointerover(e) {
+      this.hover=1;
+      this.showtip(0.6);
+    }
+    pointerout(e) {
+      this.hover=0;
+      this.showtip(0);
+    }
+    contextMenu(e){
+      if(window.webAudioControlsWidgetManager && this.midilearn)
+        webAudioControlsWidgetManager.contextMenuOpen(e,this);
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    setMidiController(channel, cc) {
+      if (this.listeningToThisMidiController(channel, cc)) return;
+      this.midiController={ 'channel': channel, 'cc': cc};
+      console.log("Added mapping for channel=" + channel + " cc=" + cc + " tooltip=" + this.tooltip);
+    }
+    listeningToThisMidiController(channel, cc) {
+      const c = this.midiController;
+      if((c.channel === channel || c.channel < 0) && c.cc === cc)
+        return true;
+      return false;
+    }
+    processMidiEvent(event){
+      const channel = event.data[0] & 0xf;
+      const controlNumber = event.data[1];
+      if(this.midiMode == 'learn') {
+        this.setMidiController(channel, controlNumber);
+        webAudioControlsWidgetManager.contextMenuClose();
+        this.midiMode = 'normal';
+        webAudioControlsWidgetManager.preserveMidiLearn();
+      }
+      if(this.listeningToThisMidiController(channel, controlNumber)) {
+        if(this.tagName=="WEBAUDIO-SWITCH"){
+          switch(this.type){
+          case "toggle":
+            if(event.data[2]>=64)
+              this.setValue(1-this.value,true);
+            break;
+          case "kick":
+            this.setValue(event.data[2]>=64?1:0);
+            break;
+          case "radio":
+            let els=document.querySelectorAll("webaudio-switch[type='radio'][group='"+this.group+"']");
+            for(let i=0;i<els.length;++i){
+              if(els[i]==this)
+                els[i].setValue(1);
+              else
+                els[i].setValue(0);
+            }
+            break;
+          }
+        }
+        else{
+          const val = this.min+(this.max-this.min)*event.data[2]/127;
+          this.setValue(val, true);
+        }
+      }
+    }
+  }
+
+try{
+    customElements.define("webaudio-knob", class WebAudioKnob extends WebAudioControlsWidget {
+    constructor(){
+      super();
+    }
+    connectedCallback(){
+      let root;
+      if(this.attachShadow)
+        root=this.attachShadow({mode: 'open'});
+      else
+        root=this;
+      root.innerHTML=
+`<style>
+${this.basestyle}
+:host{
+  display:inline-block;
+  margin:0;
+  padding:0;
+  cursor:pointer;
+  font-family: sans-serif;
+  font-size: 11px;
+}
+.webaudio-knob-body{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  vertical-align:bottom;
+  white-space:pre;
+}
+</style>
+<div class='webaudio-knob-body' tabindex='1' touch-action='none'><div class='webaudioctrl-tooltip'></div><div part="label" class="webaudioctrl-label"><slot></slot></div></div>
+`;
+      this.elem=root.childNodes[2];
+      this.ttframe=this.elem.firstChild;
+      this.label=this.ttframe.nextSibling;
+      this.enable=this.getAttr("enable",1);
+      this._src=this.getAttr("src",opt.knobSrc); if (!this.hasOwnProperty("src")) Object.defineProperty(this,"src",{get:()=>{return this._src},set:(v)=>{this._src=v;this.setupImage()}});
+      this._value=this.getAttr("value",0); if (!this.hasOwnProperty("value")) Object.defineProperty(this,"value",{get:()=>{return this._value},set:(v)=>{this._value=v;this.redraw()}});
+      this.defvalue=this.getAttr("defvalue",this._value);
+      this._min=this.getAttr("min",0); if (!this.hasOwnProperty("min")) Object.defineProperty(this,"min",{get:()=>{return this._min},set:(v)=>{this._min=+v;this.redraw()}});
+      this._max=this.getAttr("max",100); if (!this.hasOwnProperty("max")) Object.defineProperty(this,"max",{get:()=>{return this._max},set:(v)=>{this._max=+v;this.redraw()}});
+      this._step=this.getAttr("step",1); if (!this.hasOwnProperty("step")) Object.defineProperty(this,"step",{get:()=>{return this._step},set:(v)=>{this._step=+v;this.redraw()}});
+      this._sprites=this.getAttr("sprites",opt.knobSprites); if (!this.hasOwnProperty("sprites")) Object.defineProperty(this,"sprites",{get:()=>{return this._sprites},set:(v)=>{this._sprites=v;this.setupImage()}});
+      this._width=this.getAttr("width", null); if (!this.hasOwnProperty("width")) Object.defineProperty(this,"width",{get:()=>{return this._width},set:(v)=>{this._width=v;this.setupImage()}});
+      this._height=this.getAttr("height", null); if (!this.hasOwnProperty("height")) Object.defineProperty(this,"height",{get:()=>{return this._height},set:(v)=>{this._height=v;this.setupImage()}});
+      this._diameter=this.getAttr("diameter", null); if (!this.hasOwnProperty("diameter")) Object.defineProperty(this,"diameter",{get:()=>{return this._diameter},set:(v)=>{this._diameter=v;this.setupImage()}});
+      this._colors=this.getAttr("colors",opt.knobColors); if (!this.hasOwnProperty("colors")) Object.defineProperty(this,"colors",{get:()=>{return this._colors},set:(v)=>{this._colors=v;this.setupImage()}});
+      this.outline=this.getAttr("outline",opt.outline);
+      this.setupLabel();
+      this.log=this.getAttr("log",0);
+      this.sensitivity=this.getAttr("sensitivity",1);
+      this.valuetip=this.getAttr("valuetip",opt.valuetip);
+      this.tooltip=this.getAttr("tooltip",null);
+      this.conv=this.getAttr("conv",null);
+      if(this.conv){
+        const x=this._value;
+        this.convValue=eval(this.conv);
+        if(typeof(this.convValue)=="function")
+          this.convValue=this.convValue(x);
+      }
+      else
+        this.convValue=this._value;
+      this.midilearn=this.getAttr("midilearn",opt.midilearn);
+      this.midicc=this.getAttr("midicc",null);
+      this.midiController={};
+      this.midiMode="normal";
+      if(this.midicc) {
+          let ch = parseInt(this.midicc.substring(0, this.midicc.lastIndexOf("."))) - 1;
+          let cc = parseInt(this.midicc.substring(this.midicc.lastIndexOf(".") + 1));
+          this.setMidiController(ch, cc);
+      }
+      if(this.midilearn && this.id){
+        if(webAudioControlsWidgetManager && webAudioControlsWidgetManager.midiLearnTable){
+          const ml=webAudioControlsWidgetManager.midiLearnTable;
+          for(let i=0; i < ml.length; ++i){
+            if(ml[i].id==this.id){
+              this.setMidiController(ml[i].cc.channel, ml[i].cc.cc);
+              break;
+            }
+          }
+        }
+      }
+      this.setupImage();
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      this._setValue(this._value);
+      this.coltab=["#e00","#000","#000"];
+      if(window.webAudioControlsWidgetManager)
+        window.webAudioControlsWidgetManager.addWidget(this);
+    }
+    disconnectedCallback(){}
+    setupImage(){
+      this.kw=this._width||this._diameter||opt.knobWidth||opt.knobDiameter;
+      this.kh=this._height||this._diameter||opt.knobHeight||opt.knobDiameter;
+      if(!this.src){
+        if(this.colors)
+          this.coltab = this.colors.split(";");
+        if(!this.coltab)
+          this.coltab=["#e00","#000","#000"];
+        let svg=
+`<svg xmlns="http://www.w3.org/2000/svg" width="64" height="6464" preserveAspectRatio="none">
+<defs>
+  <filter id="f1">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="0.8" />
+  </filter>
+  <radialGradient id="g1" cx="50%" cy="10%">
+    <stop offset="0%" stop-color="${this.coltab[2]}"/>
+    <stop offset="100%" stop-color="${this.coltab[1]}"/>
+  </radialGradient>
+  <linearGradient id="g2" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000" stop-opacity="0.3"/>
+  </linearGradient>
+  <g id="B">
+    <circle cx="32" cy="32" r="31" fill="#000"/>
+    <circle cx="32" cy="32" r="29" fill="url(#g1)"/>
+    <circle cx="32" cy="32" r="29" fill="url(#g2)"/>
+    <circle cx="32" cy="32" r="25" fill="${this.coltab[1]}" filter="url(#f1)"/>
+    <circle cx="32" cy="32" r="29" fill="url(#g2)"/>
+  </g>
+  <line id="K" x1="32" y1="25" x2="32" y2="11" stroke-linecap="round" stroke-width="6" stroke="${this.coltab[0]}"/>
+</defs>`;
+        for(let i=0;i<101;++i){
+          svg += `<use href="#B" y="${64*i}"/><use href="#K" y="${64*i}" transform="rotate(${(-135+270*i/101).toFixed(2)},32,${64*i+32})"/>`;
+        }
+        svg += "</svg>";
+        this.elem.style.backgroundImage = "url(data:image/svg+xml;base64,"+btoa(svg)+")";
+        if(this.kw==null) this.kw=64;
+        if(this.kh==null) this.kh=64;
+        this.elem.style.backgroundSize = `${this.kw}px ${this.kh*101}px`;
+        this.elem.style.width=this.kw+"px";
+        this.elem.style.height=this.kh+"px";
+        this.style.height=this.kh+"px";
+        this.fireflag=true;
+        this.redraw();
+        return;
+      }
+      else{
+        this.img=new Image();
+        this.img.onload=()=>{
+          this.elem.style.backgroundImage = "url("+(this.src)+")";
+          if(this._sprites==null)
+            this._sprites=this.img.height/this.img.width - 1;
+          else
+            this._sprites=+this._sprites;
+          if(this.kw==null) this.kw=this.img.width;
+          if(this.kh==null) this.kh=this.img.height/(this.sprites+1);
+          if(!this.sprites)
+            this.elem.style.backgroundSize = "100% 100%";
+          else
+            this.elem.style.backgroundSize = `${this.kw}px ${this.kh*(this.sprites+1)}px`;
+          this.elem.style.width=this.kw+"px";
+          this.elem.style.height=this.kh+"px";
+          this.style.height=this.kh+"px";
+          this.redraw();
+        };
+        this.img.src=this.src;
+      }
+    }
+    redraw() {
+      let ratio;
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      if(this.value<this.min){
+        this.value=this.min;
+      }
+      if(this.value>this.max){
+        this.value=this.max;
+      }
+      if(this.log)
+        ratio = Math.log(this.value/this.min) / Math.log(this.max/this.min);
+      else
+        ratio = (this.value - this.min) / (this.max - this.min);
+      let style = this.elem.style;
+      let sp = this.src?this.sprites:100;
+      if(sp>=1){
+        let offset = (sp * ratio) | 0;
+        style.backgroundPosition = "0px " + (-offset*this.kh) + "px";
+        style.transform = 'rotate(0deg)';
+      } else {
+        let deg = 270 * (ratio - 0.5);
+        style.backgroundPosition="0px 0px";
+        style.transform = 'rotate(' + deg + 'deg)';
+      }
+    }
+    _setValue(v){
+      if(this.step)
+        v=(Math.round((v-this.min)/this.step))*this.step+this.min;
+      this._value=Math.min(this.max,Math.max(this.min,v));
+      if(this._value!=this.oldvalue){
+        this.fireflag=true;
+        this.oldvalue=this._value;
+        if(this.conv){
+          const x=this._value;
+          this.convValue=eval(this.conv);
+          if(typeof(this.convValue)=="function")
+            this.convValue=this.convValue(x);
+        }
+        else
+          this.convValue=this._value;
+        if(typeof(this.convValue)=="number"){
+          this.convValue=this.convValue.toFixed(this.digits);
+        }
+        this.redraw();
+        this.showtip(0);
+        return 1;
+      }
+      return 0;
+    }
+    setValue(v,f){
+      if(this._setValue(v) && f)
+        this.sendEvent("input"),this.sendEvent("change");
+    }
+    keydown(e){
+      const delta = this.step;
+      if(delta==0)
+        delta=1;
+      switch(e.key){
+      case "ArrowUp":
+        this.setValue(this.value+delta,true);
+        break;
+      case "ArrowDown":
+        this.setValue(this.value-delta,true);
+        break;
+      default:
+          return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    wheel(e) {
+      if (!this.enable)
+        return;
+      if(this.log){
+        let r=Math.log(this.value/this.min)/Math.log(this.max/this.min);
+        let d = (e.deltaY>0?-0.01:0.01);
+        if(!e.shiftKey)
+          d*=5;
+        r += d;
+        this.setValue(this.min*Math.pow(this.max/this.min,r),true);
+      }
+      else{
+        let delta=Math.max(this.step, (this.max-this.min)*0.05);
+        if(e.shiftKey)
+          delta=this.step?this.step:1;
+        delta=e.deltaY>0?-delta:delta;
+        this.setValue(+this.value+delta,true);
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    pointerdown(ev){
+      if(!this.enable)
+        return;
+      let e=ev;
+      if(ev.touches){
+        e = ev.changedTouches[0];
+        this.identifier=e.identifier;
+      }
+      else {
+        if(e.buttons!=1 && e.button!=0)
+          return;
+      }
+      this.elem.focus();
+      this.drag=1;
+      this.showtip(0);
+      this.oldvalue=this._value;
+      let pointermove=(ev)=>{
+        let e=ev;
+        if(ev.touches){
+          for(let i=0;i<ev.touches.length;++i){
+            if(ev.touches[i].identifier==this.identifier){
+              e = ev.touches[i];
+              break;
+            }
+          }
+        }
+        if(this.lastShift !== e.shiftKey) {
+          this.lastShift = e.shiftKey;
+          this.startPosX = e.pageX;
+          this.startPosY = e.pageY;
+          this.startVal = this.value;
+        }
+        let offset = (this.startPosY - e.pageY - this.startPosX + e.pageX) * this.sensitivity;
+        if(this.log){
+          let r = Math.log(this.startVal / this.min) / Math.log(this.max / this.min);
+          r += offset/((e.shiftKey?4:1)*128);
+          if(r<0) r=0;
+          if(r>1) r=1;
+          this._setValue(this.min * Math.pow(this.max/this.min, r));
+        }
+        else{
+          this._setValue(this.min + ((((this.startVal + (this.max - this.min) * offset / ((e.shiftKey ? 4 : 1) * 128)) - this.min) / this.step) | 0) * this.step);
+        }
+        if(this.fireflag){
+          this.sendEvent("input");
+          this.fireflag=false;
+        }
+        if(e.preventDefault)
+          e.preventDefault();
+        if(e.stopPropagation)
+          e.stopPropagation();
+        return false;
+      }
+      let pointerup=(ev)=>{
+        let e=ev;
+        if(ev.touches){
+          for(let i=0;;){
+            if(ev.changedTouches[i].identifier==this.identifier){
+              break;
+            }
+            if(++i>=ev.changedTouches.length)
+              return;
+          }
+        }
+        this.drag=0;
+        this.showtip(0);
+        this.startPosX = this.startPosY = null;
+        window.removeEventListener('mousemove', pointermove);
+        window.removeEventListener('touchmove', pointermove, {passive:false});
+        window.removeEventListener('mouseup', pointerup);
+        window.removeEventListener('touchend', pointerup);
+        window.removeEventListener('touchcancel', pointerup);
+        document.body.removeEventListener('touchstart', preventScroll,{passive:false});
+        this.sendEvent("change");
+      }
+      let preventScroll=(e)=>{
+        e.preventDefault();
+      }
+      if(e.ctrlKey || e.metaKey)
+        this.setValue(this.defvalue,true);
+      else {
+        this.startPosX = e.pageX;
+        this.startPosY = e.pageY;
+        this.startVal = this.value;
+        window.addEventListener('mousemove', pointermove);
+        window.addEventListener('touchmove', pointermove, {passive:false});
+      }
+      window.addEventListener('mouseup', pointerup);
+      window.addEventListener('touchend', pointerup);
+      window.addEventListener('touchcancel', pointerup);
+      document.body.addEventListener('touchstart', preventScroll,{passive:false});
+      ev.preventDefault();
+      ev.stopPropagation();
+      return false;
+    }
+  });
+} catch(error){
+  console.log("webaudio-knob already defined");
+}
+
+try{
+  customElements.define("webaudio-slider", class WebAudioSlider extends WebAudioControlsWidget {
+    constructor(){
+      super();
+    }
+    connectedCallback(){
+      let root;
+      if(this.attachShadow)
+        root=this.attachShadow({mode: 'open'});
+      else
+        root=this;
+      root.innerHTML=
+`<style>
+${this.basestyle}
+:host{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  font-family: sans-serif;
+  font-size: 11px;
+  cursor:pointer;
+}
+.webaudio-slider-body{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  vertical-align:bottom;
+  white-space:pre;
+}
+.webaudio-slider-knob{
+  display:inline-block;
+  position:absolute;
+  margin:0;
+  padding:0;
+}
+</style>
+<div class='webaudio-slider-body' tabindex='1' touch-action='none'><div class='webaudio-slider-knob' touch-action='none'></div><div class='webaudioctrl-tooltip'></div><div part="label" class="webaudioctrl-label"><slot></slot></div></div>
+`;
+      this.elem=root.childNodes[2];
+      this.knob=this.elem.firstChild;
+      this.ttframe=this.knob.nextSibling;
+      this.label=this.ttframe.nextSibling;
+      this.enable=this.getAttr("enable",1);
+      this.tracking=this.getAttr("tracking","rel"); 
+      this._src=this.getAttr("src",opt.sliderSrc); if (!this.hasOwnProperty("src")) Object.defineProperty(this,"src",{get:()=>{return this._src},set:(v)=>{this._src=v;this.setupImage()}});
+      this._knobsrc=this.getAttr("knobsrc",opt.sliderKnobSrc); if (!this.hasOwnProperty("knobsrc")) Object.defineProperty(this,"knobsrc",{get:()=>{return this._knobsrc},set:(v)=>{this._knobsrc=v;this.setupImage()}});
+      this._value=this.getAttr("value",0); if (!this.hasOwnProperty("value")) Object.defineProperty(this,"value",{get:()=>{return this._value},set:(v)=>{this._value=v;this.redraw()}});
+      this.defvalue=this.getAttr("defvalue",this._value);
+      this._min=this.getAttr("min",0); if (!this.hasOwnProperty("min")) Object.defineProperty(this,"min",{get:()=>{return this._min},set:(v)=>{this._min=v;this.redraw()}});
+      this._max=this.getAttr("max",100); if (!this.hasOwnProperty("max")) Object.defineProperty(this,"max",{get:()=>{return this._max},set:(v)=>{this._max=v;this.redraw()}});
+      this._step=this.getAttr("step",1); if (!this.hasOwnProperty("step")) Object.defineProperty(this,"step",{get:()=>{return this._step},set:(v)=>{this._step=v;this.redraw()}});
+      this._sprites=this.getAttr("sprites",0); if (!this.hasOwnProperty("sprites")) Object.defineProperty(this,"sprites",{get:()=>{return this._sprites},set:(v)=>{this._sprites=v;this.setupImage()}});
+      this._direction=this.getAttr("direction",null); if (!this.hasOwnProperty("direction")) Object.defineProperty(this,"direction",{get:()=>{return this._direction},set:(v)=>{this._direction=v;this.setupImage()}});
+      this.log=this.getAttr("log",0);
+      this._width=this.getAttr("width",opt.sliderWidth); if (!this.hasOwnProperty("width")) Object.defineProperty(this,"width",{get:()=>{return this._width},set:(v)=>{this._width=v;this.setupImage()}});
+      this._height=this.getAttr("height",opt.sliderHeight); if (!this.hasOwnProperty("height")) Object.defineProperty(this,"height",{get:()=>{return this._height},set:(v)=>{this._height=v;this.setupImage()}});
+      this._knobwidth=this.getAttr("knobwidth",opt.sliderKnobWidth); if (!this.hasOwnProperty("knobwidth")) Object.defineProperty(this,"knobwidth",{get:()=>{return this._knobwidth},set:(v)=>{this._knobwidth=v;this.setupImage()}});
+      this._knobheight=this.getAttr("knobheight",opt.sliderKnobHeight); if (!this.hasOwnProperty("knobheight")) Object.defineProperty(this,"knobheight",{get:()=>{return this._knobheight},set:(v)=>{this._knobheight=v;this.setupImage()}});
+      this._ditchlength=this.getAttr("ditchlength",opt.sliderDitchlength); if (!this.hasOwnProperty("ditchlength")) Object.defineProperty(this,"ditchlength",{get:()=>{return this._ditchlength},set:(v)=>{this._ditchlength=v;this.setupImage()}});
+      this._colors=this.getAttr("colors",opt.sliderColors); if (!this.hasOwnProperty("colors")) Object.defineProperty(this,"colors",{get:()=>{return this._colors},set:(v)=>{this._colors=v;this.setupImage()}});
+      this.outline=this.getAttr("outline",opt.outline);
+      this.setupLabel();
+      this.sensitivity=this.getAttr("sensitivity",1);
+      this.valuetip=this.getAttr("valuetip",opt.valuetip);
+      this.tooltip=this.getAttr("tooltip",null);
+      this.conv=this.getAttr("conv",null);
+      if(this.conv){
+        const x=this._value;
+        this.convValue=eval(this.conv);
+        if(typeof(this.convValue)=="function")
+          this.convValue=this.convValue(x);
+      }
+      else
+        this.convValue=this._value;
+      this.midilearn=this.getAttr("midilearn",opt.midilearn);
+      this.midicc=this.getAttr("midicc",null);
+      this.midiController={};
+      this.midiMode="normal";
+      if(this.midicc) {
+          let ch = parseInt(this.midicc.substring(0, this.midicc.lastIndexOf("."))) - 1;
+          let cc = parseInt(this.midicc.substring(this.midicc.lastIndexOf(".") + 1));
+          this.setMidiController(ch, cc);
+      }
+      if(this.midilearn && this.id){
+        if(webAudioControlsWidgetManager && webAudioControlsWidgetManager.midiLearnTable){
+          const ml=webAudioControlsWidgetManager.midiLearnTable;
+          for(let i=0; i < ml.length; ++i){
+            if(ml[i].id==this.id){
+              this.setMidiController(ml[i].cc.channel, ml[i].cc.cc);
+              break;
+            }
+          }
+        }
+      }
+      this.setupImage();
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      this.fireflag=true;
+      if(window.webAudioControlsWidgetManager)
+//        window.webAudioControlsWidgetManager.updateWidgets();
+        window.webAudioControlsWidgetManager.addWidget(this);
+      this.elem.onclick=(e)=>{e.stopPropagation()};
+    }
+    disconnectedCallback(){}
+    setupImage(){
+      this.coltab = this.colors.split(";");
+      this.bodyimg=new Image();
+      this.knobimg=new Image();
+      this.srcurl=null;
+      if(this.src==null||this.src==""){
+        this.sw=+this._width;
+        this.sh=+this.height;
+        if(this._direction=="horz"){
+          if(this._width==null) this.sw=128;
+          if(this._height==null) this.sh=24;
+        }
+        else if(this._direction=="vert"){
+          if(this._width==null) this.sw=24;
+          if(this._height==null) this.sh=128;
+        }
+        else{
+          if(this._width==null) this.sw=128;
+          if(this._height==null) this.sh=24;
+        }
+        const r=Math.min(this.sw,this.sh)*0.5;
+        const svgbody=
+`<svg xmlns="http://www.w3.org/2000/svg" width="${this.sw}" height="${this.sh}" preserveAspectRatio="none">
+<defs>
+  <filter id="f1">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="0.8" />
+  </filter>
+  <linearGradient id="g1" x1="0%" y1="0%" ${(this.sw>this.sh)?'x2="0%" y2="100%"':'x2="100%" y2="0%"'}>
+    <stop offset="0%" stop-color="#000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000" stop-opacity="0.3"/>
+  </linearGradient>
+</defs>
+<rect x="1" y="1" rx="${r}" ry="${r}" width="${this.sw-2}" height="${this.sh-2}" fill="#000"/>
+<rect x="3" y="3" rx="${r}" ry="${r}" width="${this.sw-6}" height="${this.sh-6}" fill="${this.coltab[1]}" filter="url(#f1)"/>
+<rect x="1" y="1" rx="${r}" ry="${r}" width="${this.sw-2}" height="${this.sh-2}" fill="url(#g1)"/>
+</svg>`;
+        this.srcurl = "data:image/svg+xml;base64,"+btoa(svgbody);
+      }
+      else{
+        this.srcurl = this.src;
+      }
+      this.bodyimg.onload=()=>{
+        if(this.src!="")
+          this.elem.style.backgroundImage = "url("+this.srcurl+")";
+        this.sw=+this._width;
+        this.sh=+this._height;
+        if(this._width==null) this.sw=this.bodyimg.width;
+        if(this._height==null) this.sh=this.bodyimg.height;
+        if(this.dr==null){
+          if(this.sw>this.sh)
+            this.dr="horz";
+          else
+            this.dr="vert";
+        }
+        this.kw=+this._knobwidth;
+        this.kh=+this._knobheight;
+        if(this._knobsrc==null){
+          if(this._knobwidth==null) this.kw=Math.min(this.sw,this.sh);
+          if(this._knobheight==null) this.kh=Math.min(this.sw,this.sh);
+          const mm=Math.min(this.kw,this.kh)*0.5;
+          const kw2=Math.max(1,this.kw-12);
+          const kh2=Math.max(1,this.kh-12);
+          const svgknob=
+`<svg xmlns="http://www.w3.org/2000/svg" width="${this.kw}" height="${this.kh}" preserveAspectRatio="none">
+<defs>
+  <filter id="f1">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="0.8" />
+  </filter>
+  <linearGradient id="g1" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="${this.coltab[2]}"/>
+    <stop offset="50%" stop-color="${this.coltab[0]}"/>
+    <stop offset="100%" stop-color="${this.coltab[0]}" stop-opacity="0.5"/>
+  </linearGradient>
+  <linearGradient id="g2" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="${this.coltab[0]}"/>
+    <stop offset="100%" stop-color="${this.coltab[0]}"/>
+  </linearGradient>
+  <linearGradient id="g3" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000" stop-opacity="0.3"/>
+  </linearGradient>
+</defs>
+<rect x="2" y="2" width="${this.kw-4}" height="${this.kh-4}" rx="${mm}" ry="${mm}" fill="#000"/>
+<rect x="3" y="3" width="${this.kw-6}" height="${this.kh-6}" rx="${mm}" ry="${mm}" fill="url(#g1)"/>
+<rect x="6" y="6" width="${kw2}" height="${kh2}" rx="${mm}" ry="${mm}" fill="url(#g2)" filter="url(#f1)"/>
+<rect x="3" y="3" width="${this.kw-6}" height="${this.kh-6}" rx="${mm}" ry="${mm}" fill="url(#g3)"/>
+</svg>`;
+          this.knobsrcurl = "data:image/svg+xml;base64,"+btoa(svgknob);
+        }
+        else{
+          this.knobsrcurl = this.knobsrc;
+        }
+        this.knobimg.onload=()=>{
+          this.knob.style.backgroundImage = "url("+this.knobsrcurl+")";
+          if(this._knobwidth==null) this.kw=this.knobimg.width;
+          if(this._knobheight==null) this.kh=this.knobimg.height;
+          this.dlen=this.ditchlength;
+          if(this.dlen==null){
+            if(this.dr=="horz")
+              this.dlen=this.sw-this.kw;
+            else
+              this.dlen=this.sh-this.kh;
+          }
+          this.knob.style.backgroundSize = "100% 100%";
+          this.knob.style.width = this.kw+"px";
+          this.knob.style.height = this.kh+"px";
+          this.elem.style.backgroundSize = "100% 100%";
+          this.elem.style.width=this.sw+"px";
+          this.elem.style.height=this.sh+"px";
+          this.redraw();
+        };
+        this.knobimg.src=this.knobsrcurl;
+      };
+      this.bodyimg.src=this.srcurl;
+    }
+    redraw() {
+      let ratio;
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      if(this.value<this.min){
+        this.value=this.min;
+      }
+      if(this.value>this.max){
+        this.value=this.max;
+      }
+      if(this.log)
+        ratio = Math.log(this.value/this.min) / Math.log(this.max/this.min);
+      else
+        ratio = (this.value - this.min) / (this.max - this.min);
+      let style = this.knob.style;
+      if(this.dr=="horz"){
+        style.top=(this.sh-this.kh)*0.5+"px";
+        style.left=((this.sw-this.kw-this.dlen)*0.5+ratio*this.dlen)+"px";
+        this.sensex=1; this.sensey=0;
+      }
+      else{
+        style.left=(this.sw-this.kw)*0.5+"px";
+        style.top=((this.sh-this.kh-this.dlen)*0.5+(1-ratio)*this.dlen)+"px";
+        this.sensex=0; this.sensey=1;
+      }
+    }
+    _setValue(v){
+      v=(Math.round((v-this.min)/this.step))*this.step+this.min;
+      this._value=Math.min(this.max,Math.max(this.min,v));
+      if(this._value!=this.oldvalue){
+        this.oldvalue=this._value;
+        this.fireflag=true;
+        if(this.conv){
+          const x=this._value;
+          this.convValue=eval(this.conv);
+          if(typeof(this.convValue)=="function")
+            this.convValue=this.convValue(x);
+        }
+        else
+          this.convValue=this._value;
+        if(typeof(this.convValue)=="number"){
+          this.convValue=this.convValue.toFixed(this.digits);
+        }
+        this.redraw();
+        this.showtip(0);
+        return 1;
+      }
+      return 0;
+    }
+    setValue(v,f){
+      if(this._setValue(v)&&f)
+        this.sendEvent("input"),this.sendEvent("change");
+    }
+    keydown(e){
+      const delta = this.step;
+      if(delta==0)
+        delta=1;
+      switch(e.key){
+      case "ArrowUp":
+        this.setValue(this.value+delta,true);
+        break;
+      case "ArrowDown":
+        this.setValue(this.value-delta,true);
+        break;
+      default:
+          return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    wheel(e) {
+      if (!this.enable)
+        return;
+      if(this.log){
+        let r=Math.log(this.value/this.min)/Math.log(this.max/this.min);
+        let d = (e.deltaY>0?-0.01:0.01);
+        if(!e.shiftKey)
+          d*=5;
+        r += d;
+        this.setValue(this.min*Math.pow(this.max/this.min,r),true);
+      }
+      else{
+        let delta=Math.max(this.step, (this.max-this.min)*0.05);
+        if(e.shiftKey)
+          delta=this.step?this.step:1;
+        delta=e.deltaY>0?-delta:delta;
+        this.setValue(+this.value+delta,true);
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    pointerdown(ev){
+      if(!this.enable)
+        return;
+      let e=ev;
+      if(ev.touches){
+        e = ev.changedTouches[0];
+        this.identifier=e.identifier;
+      }
+      else {
+        if(e.buttons!=1 && e.button!=0)
+          return;
+      }
+      this.elem.focus();
+      this.drag=1;
+      this.showtip(0);
+      let pointermove=(ev)=>{
+        let e=ev;
+        if(ev.touches){
+          for(let i=0;i<ev.touches.length;++i){
+            if(ev.touches[i].identifier==this.identifier){
+              e = ev.touches[i];
+              break;
+            }
+          }
+        }
+        if(this.lastShift !== e.shiftKey) {
+          this.lastShift = e.shiftKey;
+          this.startPosX = e.pageX;
+          this.startPosY = e.pageY;
+          this.startVal = this.value;
+        }
+        if(this.tracking=="abs"){
+          const rc = this.getBoundingClientRect();
+          let val;
+          if(this.dr=="horz")
+            val = Math.max(0,Math.min(1,(e.pageX-rc.left-window.pageXOffset-this.kw*0.5)/(this.width-this.kw)));
+          else
+            val = 1 - Math.max(0,Math.min(1,(e.pageY-rc.top-window.pageYOffset-this.kh*0.5)/(this.height-this.kh)));
+          if(this.log){
+            this._setValue(this.min * Math.pow(this.max/this.min, val));
+          }
+          else
+            this._setValue(this.min + (this.max - this.min)*val);
+        }
+        else{
+          let offset = ((this.startPosY - e.pageY)*this.sensey - (this.startPosX - e.pageX)*this.sensex) * this.sensitivity;
+          if(this.log){
+            let r = Math.log(this.startVal / this.min) / Math.log(this.max / this.min);
+            r += offset/((e.shiftKey?4:1)*128);
+            if(r<0) r=0;
+            if(r>1) r=1;
+            this._setValue(this.min * Math.pow(this.max/this.min, r));
+          }
+          else{
+            this._setValue(this.min + ((((this.startVal + (this.max - this.min) * offset / ((e.shiftKey ? 4 : 1) * this.dlen)) - this.min) / this.step) | 0) * this.step);
+          }
+        }
+        if(this.fireflag){
+          this.sendEvent("input");
+          this.fireflag=false;
+        }
+        if(e.preventDefault)
+          e.preventDefault();
+        if(e.stopPropagation)
+          e.stopPropagation();
+        return false;
+      }
+      let pointerup=(ev)=>{
+        let e=ev;
+        if(ev.touches){
+          for(let i=0;;){
+            if(ev.changedTouches[i].identifier==this.identifier){
+              break;
+            }
+            if(++i>=ev.changedTouches.length)
+              return;
+          }
+        }
+        this.drag=0;
+        this.showtip(0);
+        this.startPosX = this.startPosY = null;
+        window.removeEventListener('mousemove', pointermove);
+        window.removeEventListener('touchmove', pointermove, {passive:false});
+        window.removeEventListener('mouseup', pointerup);
+        window.removeEventListener('touchend', pointerup);
+        window.removeEventListener('touchcancel', pointerup);
+        document.body.removeEventListener('touchstart', preventScroll,{passive:false});
+        this.sendEvent("change");
+      }
+      let preventScroll=(e)=>{
+        e.preventDefault();
+      }
+      if(e.touches)
+        e = e.touches[0];
+      if(e.ctrlKey || e.metaKey)
+        this.setValue(this.defvalue,true);
+      else {
+        this.startPosX = e.pageX;
+        this.startPosY = e.pageY;
+        this.startVal = this.value;
+        window.addEventListener('mousemove', pointermove);
+        window.addEventListener('touchmove', pointermove, {passive:false});
+        pointermove(ev);
+      }
+      window.addEventListener('mouseup', pointerup);
+      window.addEventListener('touchend', pointerup);
+      window.addEventListener('touchcancel', pointerup);
+      document.body.addEventListener('touchstart', preventScroll,{passive:false});
+      e.preventDefault();
+      e.stopPropagation();
+      return false;
+    }
+  });
+} catch(error){
+  console.log("webaudio-slider already defined");
+}
+
+try{
+  customElements.define("webaudio-switch", class WebAudioSwitch extends WebAudioControlsWidget {
+    constructor(){
+      super();
+    }
+    connectedCallback(){
+      let root;
+      if(this.attachShadow)
+        root=this.attachShadow({mode: 'open'});
+      else
+        root=this;
+      root.innerHTML=
+`<style>
+${this.basestyle}
+:host{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  font-family: sans-serif;
+  font-size: 11px;
+  cursor:pointer;
+}
+.webaudio-switch-body{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  vertical-align:bottom;
+  white-space:pre;
+}
+.webaudioctrl-label{
+  position:absolute;
+  left:50%;
+  top:50%;
+}
+</style>
+<div class='webaudio-switch-body' tabindex='1' touch-action='none'><div class='webaudioctrl-tooltip'></div><div part="label" class="webaudioctrl-label"><slot></slot></div></div>
+`;
+      this.elem=root.childNodes[2];
+      this.ttframe=this.elem.firstChild;
+      this.label=this.ttframe.nextSibling;
+      this.enable=this.getAttr("enable",1);
+      this._src=this.getAttr("src",null); if (!this.hasOwnProperty("src")) Object.defineProperty(this,"src",{get:()=>{return this._src},set:(v)=>{this._src=v;this.setupImage()}});
+      this._value=this.getAttr("value",0); if (!this.hasOwnProperty("value")) Object.defineProperty(this,"value",{get:()=>{return this._value},set:(v)=>{this._value=v;this.redraw()}});
+      this.defvalue=this.getAttr("defvalue",this._value);
+      this.type=this.getAttr("type","toggle");
+      this.group=this.getAttr("group","");
+      this._width=this.getAttr("width",null); if (!this.hasOwnProperty("width")) Object.defineProperty(this,"width",{get:()=>{return this._width},set:(v)=>{this._width=v;this.setupImage()}});
+      this._height=this.getAttr("height",null); if (!this.hasOwnProperty("height")) Object.defineProperty(this,"height",{get:()=>{return this._height},set:(v)=>{this._height=v;this.setupImage()}});
+      this._diameter=this.getAttr("diameter",null); if (!this.hasOwnProperty("diameter")) Object.defineProperty(this,"diameter",{get:()=>{return this._diameter},set:(v)=>{this._diameter=v;this.setupImage()}});
+      this.invert=this.getAttr("invert",0);
+      this._colors=this.getAttr("colors",opt.switchColors); if (!this.hasOwnProperty("colors")) Object.defineProperty(this,"colors",{get:()=>{return this._colors},set:(v)=>{this._colors=v;this.setupImage()}});
+      this.outline=this.getAttr("outline",opt.outline);
+      this.setupLabel();
+      this.valuetip=0;
+      this.tooltip=this.getAttr("tooltip",null);
+      this.midilearn=this.getAttr("midilearn",opt.midilearn);
+      this.midicc=this.getAttr("midicc",null);
+      this.midiController={};
+      this.midiMode="normal";
+      if(this.midicc) {
+          let ch = parseInt(this.midicc.substring(0, this.midicc.lastIndexOf("."))) - 1;
+          let cc = parseInt(this.midicc.substring(this.midicc.lastIndexOf(".") + 1));
+          this.setMidiController(ch, cc);
+      }
+      if(this.midilearn && this.id){
+        if(webAudioControlsWidgetManager && webAudioControlsWidgetManager.midiLearnTable){
+          const ml=webAudioControlsWidgetManager.midiLearnTable;
+          for(let i=0; i < ml.length; ++i){
+            if(ml[i].id==this.id){
+              this.setMidiController(ml[i].cc.channel, ml[i].cc.cc);
+              break;
+            }
+          }
+        }
+      }
+      this.setupImage();
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      if(window.webAudioControlsWidgetManager)
+//        window.webAudioControlsWidgetManager.updateWidgets();
+        window.webAudioControlsWidgetManager.addWidget(this);
+      this.elem.onclick=(e)=>{e.stopPropagation()};
+    }
+    disconnectedCallback(){}
+    setupImage(){
+      this.coltab = this.colors.split(";");
+      this.kw=this._width||this._diameter||opt.switchWidth||opt.switchDiameter;
+      this.kh=this._height||this._diameter||opt.switchHeight||opt.switchDiameter;
+      this.img=new Image();
+      this.srcurl=null;
+      if(this.src==null||this.src==""){
+        if(this.kw==null) this.kw=32;
+        if(this.kh==null) this.kh=32;
+        const mm=Math.min(this.kw,this.kh);
+        const kw=this.kw,kh=this.kh;
+        const svg=
+`<svg xmlns="http://www.w3.org/2000/svg" width="${this.kw}" height="${this.kh*2}" preserveAspectRatio="none">
+<defs>
+<linearGradient id="g1" x1="0%" y1="0%" x2="0%" y2="100%">
+  <stop offset="0%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#000" stop-opacity="0.2"/>
+</linearGradient>
+<radialGradient id="g2" cx="50%" cy="30%">
+    <stop offset="0%" stop-color="${this.coltab[2]}"/>
+    <stop offset="100%" stop-color="${this.coltab[0]}"/>
+  </radialGradient>
+  <filter id="f1">
+    <feGaussianBlur in="SourceGraphic" stdDeviation=".4" />
+  </filter>
+</defs>
+<g id="p1">
+  <rect x="${kw*.075}" y="${kh*.075}" width="${kw*.85}" height="${kh*.85}" rx="${mm*.1}" ry="${mm*.1}" fill="#000"/>
+  <rect x="${kw*.1}" y="${kh*.1}" width="${kw*.8}" height="${kh*.8}" rx="${mm*.1}" ry="${mm*.1}" fill="${this.coltab[1]}"/>
+</g>
+<g id="p2">
+  <circle cx="${kw*0.5}" cy="${kh*0.5}" r="${mm*0.35}" stroke="#000" stroke-width="${mm*.03}" fill="${this.coltab[0]}" filter="url(#f1)"/>
+  <circle cx="${kw*0.5}" cy="${kh*0.5}" r="${mm*0.27}" stroke="#000" stroke-width="${mm*.03}" fill="#000" filter="url(#f1)"/>
+  <rect x="${kw*.075}" y="${kh*.075}" width="${kw*.85}" height="${kh*.85}" rx="${mm*.1}" ry="${mm*.1}" fill="url(#g1)"/>
+</g>
+<use href="#p1" y="${kh}"/>
+<use href="#p2" y="${kh}"/>
+<circle cx="${kw*.5}" cy="${kh*1.5}" r="${mm*.25}" fill="url(#g2)" filter="url(#f1)"/>
+<circle cx="${kw*.5}" cy="${kh*1.5}" r="${mm*.25}" fill="url(#g1)"/>
+</svg>`;
+        this.srcurl="data:image/svg+xml;base64,"+btoa(svg);
+      }
+      else
+        this.srcurl=this.src;
+      this.img.onload=()=>{
+        if(this.kw==null) this.kw=this.img.width;
+        if(this.kh==null) this.kh=this.img.height*0.5;
+        this.elem.style.backgroundImage = "url("+this.srcurl+")";
+        this.elem.style.backgroundSize = "100% 200%";
+        this.elem.style.width=this.kw+"px";
+        this.elem.style.height=this.kh+"px";
+        this.redraw();
+      }
+      this.img.src=this.srcurl;
+    }
+    redraw() {
+      let style = this.elem.style;
+      if(this.value^this.invert)
+        style.backgroundPosition = "0px -100%";
+      else
+        style.backgroundPosition = "0px 0px";
+    }
+    setValue(v,f){
+      this.value=v;
+      this.checked=(!!v);
+      if(this.value!=this.oldvalue){
+        this.redraw();
+        this.showtip(0);
+        if(f){
+          this.sendEvent("input");
+          this.sendEvent("change");
+        }
+        this.oldvalue=this.value;
+      }
+    }
+    pointerdown(ev){
+      if(!this.enable)
+        return;
+      let e=ev;
+      if(ev.touches){
+        e = ev.changedTouches[0];
+        this.identifier=e.identifier;
+      }
+      else {
+        if(e.buttons!=1 && e.button!=0)
+          return;
+      }
+      this.elem.focus();
+      this.drag=1;
+      this.showtip(0);
+      let pointermove=(e)=>{
+        e.preventDefault();
+        e.stopPropagation();
+        return false;
+      }
+      let pointerup=(e)=>{
+        this.drag=0;
+        this.showtip(0);
+        window.removeEventListener('mousemove', pointermove);
+        window.removeEventListener('touchmove', pointermove, {passive:false});
+        window.removeEventListener('mouseup', pointerup);
+        window.removeEventListener('touchend', pointerup);
+        window.removeEventListener('touchcancel', pointerup);
+        document.body.removeEventListener('touchstart', preventScroll,{passive:false});
+        if(this.type=="kick"){
+          this.value=0;
+          this.checked=false;
+          this.redraw();
+          this.sendEvent("change");
+        }
+        this.sendEvent("click");
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      let preventScroll=(e)=>{
+        e.preventDefault();
+      }
+      switch(this.type){
+      case "kick":
+        this.setValue(1);
+        this.sendEvent("change");
+        break;
+      case "toggle":
+        if(e.ctrlKey || e.metaKey)
+          this.value=defvalue;
+        else
+          this.value=1-this.value;
+        this.checked=!!this.value;
+        this.sendEvent("change");
+        break;
+      case "radio":
+        let els=document.querySelectorAll("webaudio-switch[type='radio'][group='"+this.group+"']");
+        for(let i=0;i<els.length;++i){
+          if(els[i]==this)
+            els[i].setValue(1);
+          else
+            els[i].setValue(0);
+        }
+        this.sendEvent("change");
+        break;
+      }
+
+      window.addEventListener('mouseup', pointerup);
+      window.addEventListener('touchend', pointerup);
+      window.addEventListener('touchcancel', pointerup);
+      document.body.addEventListener('touchstart', preventScroll,{passive:false});
+      this.redraw();
+      ev.preventDefault();
+      ev.stopPropagation();
+      return false;
+    }
+  });
+} catch(error){
+  console.log("webaudio-switch already defined");
+}
+
+try{
+  customElements.define("webaudio-param", class WebAudioParam extends WebAudioControlsWidget {
+    constructor(){
+      super();
+      this.addEventListener("keydown",this.keydown);
+      this.addEventListener("mousedown",this.pointerdown,{passive:false});
+      this.addEventListener("touchstart",this.pointerdown,{passive:false});
+      this.addEventListener("wheel",this.wheel);
+      this.addEventListener("mouseover",this.pointerover);
+      this.addEventListener("mouseout",this.pointerout);
+      this.addEventListener("contextmenu",this.contextMenu);
+    }
+    connectedCallback(){
+      let root;
+      if(this.attachShadow)
+        root=this.attachShadow({mode: 'open'});
+      else
+        root=this;
+      root.innerHTML=
+`<style>
+${this.basestyle}
+:host{
+  display:inline-block;
+  user-select:none;
+  margin:0;
+  padding:0;
+  font-family: sans-serif;
+  font-size: 8px;
+  cursor:pointer;
+  position:relative;
+  vertical-align:baseline;
+}
+.webaudio-param-body{
+  display:inline-block;
+  position:relative;
+  text-align:center;
+  background:none;
+  margin:0;
+  padding:0;
+  font-family:sans-serif;
+  font-size:11px;
+  vertical-align:bottom;
+  border:none;
+}
+</style>
+<input class='webaudio-param-body' value='0' tabindex='1' touch-action='none'/><div class='webaudioctrl-tooltip'></div>
+`;
+      this.elem=root.childNodes[2];
+      this.ttframe=root.childNodes[3];
+      this.enable=this.getAttr("enable",1);
+      this._value=this.getAttr("value",0); if (!this.hasOwnProperty("value")) Object.defineProperty(this,"value",{get:()=>{return this._value},set:(v)=>{this._value=v;this.redraw()}});
+      this.defvalue=this.getAttr("defvalue",0);
+      this._fontsize=this.getAttr("fontsize",9); if (!this.hasOwnProperty("fontsize")) Object.defineProperty(this,"fontsize",{get:()=>{return this._fontsize},set:(v)=>{this._fontsize=v;this.setupImage()}});
+      this._src=this.getAttr("src",opt.paramSrc); if (!this.hasOwnProperty("src")) Object.defineProperty(this,"src",{get:()=>{return this._src},set:(v)=>{this._src=v;this.setupImage()}});
+      this.link=this.getAttr("link","");
+      this._width=this.getAttr("width",opt.paramWidth); if (!this.hasOwnProperty("width")) Object.defineProperty(this,"width",{get:()=>{return this._width},set:(v)=>{this._width=v;this.setupImage()}});
+      this._height=this.getAttr("height",opt.paramHeight); if (!this.hasOwnProperty("height")) Object.defineProperty(this,"height",{get:()=>{return this._height},set:(v)=>{this._height=v;this.setupImage()}});
+      this._colors=this.getAttr("colors",opt.paramColors); if (!this.hasOwnProperty("colors")) Object.defineProperty(this,"colors",{get:()=>{return this._colors},set:(v)=>{this._colors=v;this.setupImage()}});
+      this.outline=this.getAttr("outline",opt.outline);
+      this.rconv=this.getAttr("rconv",null);
+      this.midiController={};
+      this.midiMode="normal";
+      this.currentLink=null;
+      if(this.midicc) {
+        let ch = parseInt(this.midicc.substring(0, this.midicc.lastIndexOf("."))) - 1;
+        let cc = parseInt(this.midicc.substring(this.midicc.lastIndexOf(".") + 1));
+        this.setMidiController(ch, cc);
+      }
+      this.setupImage();
+      if(window.webAudioControlsWidgetManager)
+//        window.webAudioControlsWidgetManager.updateWidgets();
+        window.webAudioControlsWidgetManager.addWidget(this);
+      this.fromLink=((e)=>{
+        this.setValue(e.target.convValue.toFixed(e.target.digits));
+      }).bind(this);
+      this.elem.onchange=()=>{
+        if(!this.currentLink.target.conv || (this.currentLink.target.conv&&this.rconv)){
+          let val = this.value=this.elem.value;
+          if(this.rconv){
+            let x=+this.elem.value;
+            val=eval(this.rconv);
+          }
+          if(this.currentLink){
+            this.currentLink.target.setValue(val, true);
+          }
+        }
+      }
+    }
+    disconnectedCallback(){}
+    setupImage(){
+      this.imgloaded=()=>{
+        if(this.src!=""&&this.src!=null){
+          this.elem.style.backgroundImage = "url("+this.src+")";
+          this.elem.style.backgroundSize = "100% 100%";
+          if(this._width==null) this._width=this.img.width;
+          if(this._height==null) this._height=this.img.height;
+        }
+        else{
+          if(this._width==null) this._width=32;
+          if(this._height==null) this._height=20;
+        }
+        this.elem.style.width=this._width+"px";
+        this.elem.style.height=this._height+"px";
+        this.elem.style.fontSize=this.fontsize+"px";
+        let l=document.getElementById(this.link);
+        if(l&&typeof(l.value)!="undefined"){
+          if(typeof(l.convValue)=="number")
+            this.setValue(l.convValue.toFixed(l.digits));
+          else
+            this.setValue(l.convValue);
+          if(this.currentLink)
+            this.currentLink.removeEventListener("input",this.currentLink.func);
+          this.currentLink={target:l, func:(e)=>{
+            if(typeof(l.convValue)=="number")
+              this.setValue(l.convValue.toFixed(l.digits));
+            else
+              this.setValue(l.convValue);
+          }};
+          this.currentLink.target.addEventListener("input",this.currentLink.func);
+  //        l.addEventListener("input",(e)=>{this.setValue(l.convValue.toFixed(l.digits))});
+        }
+        this.redraw();
+      };
+      this.coltab = this.colors.split(";");
+      this.elem.style.color=this.coltab[0];
+      this.img=new Image();
+      this.img.onload=this.imgloaded.bind();
+      if(this.src==null){
+        this.elem.style.backgroundColor=this.coltab[1];
+        this.imgloaded();
+      }
+      else if(this.src==""){
+        this.elem.style.background="none";
+        this.imgloaded();
+      }
+      else{
+        this.img.src=this.src;
+      }
+    }
+    redraw() {
+      this.elem.value=this.value;
+    }
+    setValue(v,f){
+      this.value=v;
+      if(this.value!=this.oldvalue){
+        this.redraw();
+        this.showtip(0);
+        if(f){
+          let event=document.createEvent("HTMLEvents");
+          event.initEvent("change",false,true);
+          this.dispatchEvent(event);
+        }
+        this.oldvalue=this.value;
+      }
+    }
+    pointerdown(ev){
+      if(!this.enable)
+        return;
+      let e=ev;
+      if(ev.touches)
+          e = ev.touches[0];
+      else {
+        if(e.buttons!=1 && e.button!=0)
+          return;
+      }
+      this.elem.focus();
+      this.redraw();
+    }
+  });
+} catch(error){
+  console.log("webaudio-param already defined");
+}
+
+try{
+  customElements.define("webaudio-keyboard", class WebAudioKeyboard extends WebAudioControlsWidget {
+    constructor(){
+      super();
+    }
+    connectedCallback(){
+      let root;
+      if(this.attachShadow)
+        root=this.attachShadow({mode: 'open'});
+      else
+        root=this;
+      root.innerHTML=
+`<style>
+${this.basestyle}
+:host{
+  display:inline-block;
+  position:relative;
+  margin:0;
+  padding:0;
+  font-family: sans-serif;
+  font-size: 11px;
+}
+.webaudio-keyboard-body{
+  display:inline-block;
+  margin:0;
+  padding:0;
+  vertical-align:bottom;
+}
+</style>
+<canvas class='webaudio-keyboard-body' tabindex='1' touch-action='none'></canvas><div class='webauioctrl-tooltip'></div>
+`;
+      this.elem=this.cv=root.childNodes[2];
+      this.ttframe=root.childNodes[3];
+      this.ctx=this.cv.getContext("2d");
+      this._values=[];
+      this.enable=this.getAttr("enable",1);
+      this._width=this.getAttr("width",480); if (!this.hasOwnProperty("width")) Object.defineProperty(this,"width",{get:()=>{return this._width},set:(v)=>{this._width=v;this.setupImage()}});
+      this._height=this.getAttr("height",128); if (!this.hasOwnProperty("height")) Object.defineProperty(this,"height",{get:()=>{return this._height},set:(v)=>{this._height=v;this.setupImage()}});
+      this._min=this.getAttr("min",0); if (!this.hasOwnProperty("min")) Object.defineProperty(this,"min",{get:()=>{return this._min},set:(v)=>{this._min=+v;this.redraw()}});
+      this._keys=this.getAttr("keys",25); if (!this.hasOwnProperty("keys")) Object.defineProperty(this,"keys",{get:()=>{return this._keys},set:(v)=>{this._keys=+v;this.setupImage()}});
+      this._colors=this.getAttr("colors","#222;#eee;#ccc;#333;#000;#e88;#c44;#c33;#800"); if (!this.hasOwnProperty("colors")) Object.defineProperty(this,"colors",{get:()=>{return this._colors},set:(v)=>{this._colors=v;this.setupImage()}});
+      this.outline=this.getAttr("outline",opt.outline);
+      this.midilearn=this.getAttr("midilearn",0);
+      this.midicc=this.getAttr("midicc",null);
+      this.press=0;
+      this.keycodes1=[90,83,88,68,67,86,71,66,72,78,74,77,188,76,190,187,191,226];
+      this.keycodes2=[81,50,87,51,69,82,53,84,54,89,55,85,73,57,79,48,80,192,222,219];
+      this.addEventListener("keyup",this.keyup);
+      this.midiController={};
+      this.midiMode="normal";
+      if(this.midicc) {
+          let ch = parseInt(this.midicc.substring(0, this.midicc.lastIndexOf("."))) - 1;
+          let cc = parseInt(this.midicc.substring(this.midicc.lastIndexOf(".") + 1));
+          this.setMidiController(ch, cc);
+      }
+      this.setupImage();
+      this.digits=0;
+      if(this.step && this.step < 1) {
+        for(let n = this.step ; n < 1; n *= 10)
+          ++this.digits;
+      }
+      if(window.webAudioControlsWidgetManager)
+        window.webAudioControlsWidgetManager.addWidget(this);
+    }
+    disconnectedCallback(){}
+    setupImage(){
+      this.cv.style.width=this.width+"px";
+      this.cv.style.height=this.height+"px";
+      this.bheight = this.height * 0.55;
+      this.kp=[0,7/12,1,3*7/12,2,3,6*7/12,4,8*7/12,5,10*7/12,6];
+      this.kf=[0,1,0,1,0,0,1,0,1,0,1,0];
+      this.ko=[0,0,(7*2)/12-1,0,(7*4)/12-2,(7*5)/12-3,0,(7*7)/12-4,0,(7*9)/12-5,0,(7*11)/12-6];
+      this.kn=[0,2,4,5,7,9,11];
+      this.coltab=this.colors.split(";");
+      this.cv.width = this.width;
+      this.cv.height = this.height;
+      this.cv.style.width = this.width+'px';
+      this.cv.style.height = this.height+'px';
+      this.style.height = this.height+'px';
+      this.cv.style.outline=this.outline?"":"none";
+      this.bheight = this.height * 0.55;
+      this.max=this.min+this.keys-1;
+      this.dispvalues=[];
+      this.valuesold=[];
+      if(this.kf[this.min%12])
+        --this.min;
+      if(this.kf[this.max%12])
+        ++this.max;
+      this.redraw();
+    }
+    redraw(){
+      function rrect(ctx, x, y, w, h, r, c1, c2) {
+        if(c2) {
+          let g=ctx.createLinearGradient(x,y,x+w,y);
+          g.addColorStop(0,c1);
+          g.addColorStop(1,c2);
+          ctx.fillStyle=g;
+        }
+        else
+          ctx.fillStyle=c1;
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.lineTo(x+w, y);
+        ctx.lineTo(x+w, y+h-r);
+        ctx.quadraticCurveTo(x+w, y+h, x+w-r, y+h);
+        ctx.lineTo(x+r, y+h);
+        ctx.quadraticCurveTo(x, y+h, x, y+h-r);
+        ctx.lineTo(x, y);
+        ctx.fill();
+      }
+      this.ctx.fillStyle = this.coltab[0];
+      this.ctx.fillRect(0,0,this.width,this.height);
+      let x0=7*((this.min/12)|0)+this.kp[this.min%12];
+      let x1=7*((this.max/12)|0)+this.kp[this.max%12];
+      let n=x1-x0;
+      this.wwidth=(this.width-1)/(n+1);
+      this.bwidth=this.wwidth*7/12;
+      let h2=this.bheight;
+      let r=Math.min(8,this.wwidth*0.2);
+      for(let i=this.min,j=0;i<=this.max;++i) {
+        if(this.kf[i%12]==0) {
+          let x=this.wwidth*(j++)+1;
+          if(this.dispvalues.indexOf(i)>=0)
+            rrect(this.ctx,x,1,this.wwidth-1,this.height-2,r,this.coltab[5],this.coltab[6]);
+          else
+            rrect(this.ctx,x,1,this.wwidth-1,this.height-2,r,this.coltab[1],this.coltab[2]);
+        }
+      }
+      r=Math.min(8,this.bwidth*0.3);
+      for(let i=this.min;i<this.max;++i) {
+        if(this.kf[i%12]) {
+          let x=this.wwidth*this.ko[this.min%12]+this.bwidth*(i-this.min)+1;
+          if(this.dispvalues.indexOf(i)>=0)
+            rrect(this.ctx,x,1,this.bwidth,h2,r,this.coltab[7],this.coltab[8]);
+          else
+            rrect(this.ctx,x,1,this.bwidth,h2,r,this.coltab[3],this.coltab[4]);
+          this.ctx.strokeStyle=this.coltab[0];
+          this.ctx.stroke();
+        }
+      }
+    }
+    _setValue(v){
+      if(this.step)
+        v=(Math.round((v-this.min)/this.step))*this.step+this.min;
+      this._value=Math.min(this.max,Math.max(this.min,v));
+      if(this._value!=this.oldvalue){
+        this.oldvalue=this._value;
+        this.redraw();
+        this.showtip(0);
+        return 1;
+      }
+      return 0;
+    }
+    setValue(v,f){
+      if(this._setValue(v) && f)
+        this.sendEvent("input"),this.sendEvent("change");
+    }
+    wheel(e){}
+    keydown(e){
+      let m=Math.floor((this.min+11)/12)*12;
+      let k=this.keycodes1.indexOf(e.keyCode);
+      if(k<0) {
+        k=this.keycodes2.indexOf(e.keyCode);
+        if(k>=0) k+=12;
+      }
+      if(k>=0){
+        k+=m;
+        if(this.currentKey!=k){
+          this.currentKey=k;
+          this.sendEventFromKey(1,k);
+          this.setNote(1,k);
+        }
+      }
+    }
+    keyup(e){
+      let m=Math.floor((this.min+11)/12)*12;
+      let k=this.keycodes1.indexOf(e.keyCode);
+      if(k<0) {
+        k=this.keycodes2.indexOf(e.keyCode);
+        if(k>=0) k+=12;
+      }
+      if(k>=0){
+        k+=m;
+        this.currentKey=-1;
+        this.sendEventFromKey(0,k);
+        this.setNote(0,k);
+      }
+    }
+    pointerdown(ev){
+      this.cv.focus();
+      if(this.enable) {
+        ++this.press;
+      }
+      let pointermove=(ev)=>{
+        if(!this.enable)
+          return;
+        let r=this.getBoundingClientRect();
+        let v=[],p;
+        if(ev.touches)
+          p=ev.targetTouches;
+        else if(this.press)
+          p=[ev];
+        else
+          p=[];
+        if(p.length>0)
+          this.drag=1;
+        for(let i=0;i<p.length;++i) {
+          let px=p[i].clientX-r.left;
+          let py=p[i].clientY-r.top;
+          let x,k,ko;
+          if(py>=0&&py<this.height){
+            if(py<this.bheight) {
+              x=px-this.wwidth*this.ko[this.min%12];
+              k=this.min+((x/this.bwidth)|0);
+            }
+            else {
+              k=(px/this.wwidth)|0;
+              ko=this.kp[this.min%12];
+              k+=ko;
+              k=this.min+((k/7)|0)*12+this.kn[k%7]-this.kn[ko%7];
+            }
+            if(k>=this.min&&k<=this.max)
+              v.push(k);
+          }
+        }
+        v.sort();
+        this.values=v;
+        this.sendevent();
+        this.redraw();
+      }
+        
+      let pointerup=(ev)=>{
+        if(this.enable) {
+          if(ev.touches)
+            this.press=ev.touches.length;
+          else
+            this.press=0;
+          pointermove(ev);
+          this.sendevent();
+          if(this.press==0){
+            window.removeEventListener('mousemove', pointermove);
+            window.removeEventListener('touchmove', pointermove, {passive:false});
+            window.removeEventListener('mouseup', pointerup);
+            window.removeEventListener('touchend', pointerup);
+            window.removeEventListener('touchcancel', pointerup);
+            document.body.removeEventListener('touchstart', preventScroll,{passive:false});
+          }
+          this.redraw();
+        }
+        this.drag=0;
+        ev.preventDefault();
+      }
+      let preventScroll=(ev)=>{
+        ev.preventDefault();
+      }
+      window.addEventListener('mousemove', pointermove);
+      window.addEventListener('touchmove', pointermove, {passive:false});
+      window.addEventListener('mouseup', pointerup);
+      window.addEventListener('touchend', pointerup);
+      window.addEventListener('touchcancel', pointerup);
+      document.body.addEventListener('touchstart', preventScroll,{passive:false});
+      pointermove(ev);
+      ev.preventDefault();
+      ev.stopPropagation();
+    }
+    sendEventFromKey(s,k){
+      let ev=document.createEvent('HTMLEvents');
+      ev.initEvent('change',true,true);
+      ev.note=[s,k];
+      this.dispatchEvent(ev);
+    }
+    sendevent(){
+      let notes=[];
+      for(let i=0,j=this.valuesold.length;i<j;++i) {
+        if(this.values.indexOf(this.valuesold[i])<0)
+          notes.push([0,this.valuesold[i]]);
+      }
+      for(let i=0,j=this.values.length;i<j;++i) {
+        if(this.valuesold.indexOf(this.values[i])<0)
+          notes.push([1,this.values[i]]);
+      }
+      if(notes.length) {
+        this.valuesold=this.values;
+        for(let i=0;i<notes.length;++i) {
+          this.setdispvalues(notes[i][0],notes[i][1]);
+          let ev=document.createEvent('HTMLEvents');
+          ev.initEvent('change',true,true);
+          ev.note=notes[i];
+          this.dispatchEvent(ev);
+        }
+      }
+    }
+    setdispvalues(state,note) {
+      let n=this.dispvalues.indexOf(note);
+      if(state) {
+        if(n<0) this.dispvalues.push(note);
+      }
+      else {
+        if(n>=0) this.dispvalues.splice(n,1);
+      }
+    }
+    setNote(state,note,actx,when) {
+      const t=(actx&&when-actx.currentTime);
+      if(t>0){
+        setTimeout(()=>{this.setNote(state,note)},t*1000);
+      }
+      else{
+        this.setdispvalues(state,note);
+        this.redraw();
+      }
+    }  });
+} catch(error){
+  console.log("webaudio-keyboard already defined");
+}
+
+  class WebAudioControlsWidgetManager {
+    constructor(){
+      this.midiAccess = null;
+      this.listOfWidgets = [];
+      this.listOfExternalMidiListeners = [];
+      this.updateWidgets();
+      if(opt.preserveMidiLearn)
+        this.midiLearnTable=JSON.parse(localStorage.getItem("WebAudioControlsMidiLearn"));
+      else
+        this.midiLearnTable=null;
+      this.initWebAudioControls();
+    }
+    addWidget(w){
+      this.listOfWidgets.push(w);
+    }
+    updateWidgets(){
+//      this.listOfWidgets = document.querySelectorAll("webaudio-knob,webaudio-slider,webaudio-switch");
+    }
+    initWebAudioControls() {
+      if(navigator.requestMIDIAccess) {
+        navigator.requestMIDIAccess().then(
+          (ma)=>{this.midiAccess = ma,this.enableInputs()},
+          (err)=>{ console.log("MIDI not initialized - error encountered:" + err.code)}
+        );
+      }
+    }
+    enableInputs() {
+      let inputs = this.midiAccess.inputs.values();
+      console.log("Found " + this.midiAccess.inputs.size + " MIDI input(s)");
+      for(let input = inputs.next(); input && !input.done; input = inputs.next()) {
+        console.log("Connected input: " + input.value.name);
+        input.value.onmidimessage = this.handleMIDIMessage.bind(this);
+      }
+    }
+    midiConnectionStateChange(e) {
+      console.log("connection: " + e.port.name + " " + e.port.connection + " " + e.port.state);
+      enableInputs();
+    }
+
+    onMIDIStarted(midi) {
+      this.midiAccess = midi;
+      midi.onstatechange = this.midiConnectionStateChange;
+      enableInputs(midi);
+    }
+    // Add hooks for external midi listeners support
+    addMidiListener(callback) {
+      this.listOfExternalMidiListeners.push(callback);
+    }
+    getCurrentConfigAsJSON() {
+      return currentConfig.stringify();
+    }
+    handleMIDIMessage(event) {
+      this.listOfExternalMidiListeners.forEach(function (externalListener) {
+        externalListener(event);
+      });
+      if(((event.data[0] & 0xf0) == 0xf0) || ((event.data[0] & 0xf0) == 0xb0 && event.data[1] >= 120))
+        return;
+      for(let w of this.listOfWidgets) {
+        if(w.processMidiEvent)
+          w.processMidiEvent(event);
+      }
+      if(opt.mididump)
+        console.log(event.data);
+    }
+    contextMenuOpen(e,knob){
+      if(!this.midiAccess)
+        return;
+      let menu=document.getElementById("webaudioctrl-context-menu");
+      menu.style.left=e.pageX+"px";
+      menu.style.top=e.pageY+"px";
+      menu.knob=knob;
+      menu.classList.add("active");
+      menu.knob.focus();
+      menu.knob.addEventListener("keydown",this.contextMenuCloseByKey.bind(this));
+    }
+    contextMenuCloseByKey(e){
+      if(e.keyCode==27)
+       this.contextMenuClose();
+    }
+    contextMenuClose(){
+      let menu=document.getElementById("webaudioctrl-context-menu");
+      menu.knob.removeEventListener("keydown",this.contextMenuCloseByKey);
+      menu.classList.remove("active");
+      let menuItemLearn=document.getElementById("webaudioctrl-context-menu-learn");
+      menuItemLearn.innerHTML = 'Learn';
+      menu.knob.midiMode = 'normal';
+    }
+    contextMenuLearn(){
+      let menu=document.getElementById("webaudioctrl-context-menu");
+      let menuItemLearn=document.getElementById("webaudioctrl-context-menu-learn");
+      menuItemLearn.innerHTML = 'Listening...';
+      menu.knob.midiMode = 'learn';
+    }
+    contextMenuClear(e){
+      let menu=document.getElementById("webaudioctrl-context-menu");
+      menu.knob.midiController={};
+      this.contextMenuClose();
+    }
+    preserveMidiLearn(){
+      if(!opt.preserveMidiLearn)
+        return;
+      const v=[];
+      for(let w of this.listOfWidgets) {
+        if(w.id)
+          v.push({"id":w.id, "cc":w.midiController});
+      }
+      const s=JSON.stringify(v);
+      localStorage.setItem("WebAudioControlsMidiLearn",s);
+    }
+  }
+  if(window.UseWebAudioControlsMidi||opt.useMidi)
+    window.webAudioControlsWidgetManager = window.webAudioControlsMidiManager = new WebAudioControlsWidgetManager();
+}

--- a/src/webaudio-controls.js
+++ b/src/webaudio-controls.js
@@ -569,23 +569,23 @@ ${this.basestyle}
       if(this._setValue(v) && f)
         this.sendEvent("input"),this.sendEvent("change");
     }
-    keydown(e){
-      const delta = this.step;
-      if(delta==0)
-        delta=1;
-      switch(e.key){
-      case "ArrowUp":
-        this.setValue(this.value+delta,true);
-        break;
-      case "ArrowDown":
-        this.setValue(this.value-delta,true);
-        break;
-      default:
-          return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-    }
+    // keydown(e){
+    //   const delta = this.step;
+    //   if(delta==0)
+    //     delta=1;
+    //   switch(e.key){
+    //   case "ArrowUp":
+    //     this.setValue(this.value+delta,true);
+    //     break;
+    //   case "ArrowDown":
+    //     this.setValue(this.value-delta,true);
+    //     break;
+    //   default:
+    //       return;
+    //   }
+    //   e.preventDefault();
+    //   e.stopPropagation();
+    // }
     wheel(e) {
       if (!this.enable)
         return;
@@ -752,7 +752,7 @@ ${this.basestyle}
       this.ttframe=this.knob.nextSibling;
       this.label=this.ttframe.nextSibling;
       this.enable=this.getAttr("enable",1);
-      this.tracking=this.getAttr("tracking","rel"); 
+      this.tracking=this.getAttr("tracking","rel");
       this._src=this.getAttr("src",opt.sliderSrc); if (!this.hasOwnProperty("src")) Object.defineProperty(this,"src",{get:()=>{return this._src},set:(v)=>{this._src=v;this.setupImage()}});
       this._knobsrc=this.getAttr("knobsrc",opt.sliderKnobSrc); if (!this.hasOwnProperty("knobsrc")) Object.defineProperty(this,"knobsrc",{get:()=>{return this._knobsrc},set:(v)=>{this._knobsrc=v;this.setupImage()}});
       this._value=this.getAttr("value",0); if (!this.hasOwnProperty("value")) Object.defineProperty(this,"value",{get:()=>{return this._value},set:(v)=>{this._value=v;this.redraw()}});
@@ -987,23 +987,23 @@ ${this.basestyle}
       if(this._setValue(v)&&f)
         this.sendEvent("input"),this.sendEvent("change");
     }
-    keydown(e){
-      const delta = this.step;
-      if(delta==0)
-        delta=1;
-      switch(e.key){
-      case "ArrowUp":
-        this.setValue(this.value+delta,true);
-        break;
-      case "ArrowDown":
-        this.setValue(this.value-delta,true);
-        break;
-      default:
-          return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-    }
+    // keydown(e){
+    //   const delta = this.step;
+    //   if(delta==0)
+    //     delta=1;
+    //   switch(e.key){
+    //   case "ArrowUp":
+    //     this.setValue(this.value+delta,true);
+    //     break;
+    //   case "ArrowDown":
+    //     this.setValue(this.value-delta,true);
+    //     break;
+    //   default:
+    //       return;
+    //   }
+    //   e.preventDefault();
+    //   e.stopPropagation();
+    // }
     wheel(e) {
       if (!this.enable)
         return;
@@ -1718,36 +1718,36 @@ ${this.basestyle}
         this.sendEvent("input"),this.sendEvent("change");
     }
     wheel(e){}
-    keydown(e){
-      let m=Math.floor((this.min+11)/12)*12;
-      let k=this.keycodes1.indexOf(e.keyCode);
-      if(k<0) {
-        k=this.keycodes2.indexOf(e.keyCode);
-        if(k>=0) k+=12;
-      }
-      if(k>=0){
-        k+=m;
-        if(this.currentKey!=k){
-          this.currentKey=k;
-          this.sendEventFromKey(1,k);
-          this.setNote(1,k);
-        }
-      }
-    }
-    keyup(e){
-      let m=Math.floor((this.min+11)/12)*12;
-      let k=this.keycodes1.indexOf(e.keyCode);
-      if(k<0) {
-        k=this.keycodes2.indexOf(e.keyCode);
-        if(k>=0) k+=12;
-      }
-      if(k>=0){
-        k+=m;
-        this.currentKey=-1;
-        this.sendEventFromKey(0,k);
-        this.setNote(0,k);
-      }
-    }
+    // keydown(e){
+    //   let m=Math.floor((this.min+11)/12)*12;
+    //   let k=this.keycodes1.indexOf(e.keyCode);
+    //   if(k<0) {
+    //     k=this.keycodes2.indexOf(e.keyCode);
+    //     if(k>=0) k+=12;
+    //   }
+    //   if(k>=0){
+    //     k+=m;
+    //     if(this.currentKey!=k){
+    //       this.currentKey=k;
+    //       this.sendEventFromKey(1,k);
+    //       this.setNote(1,k);
+    //     }
+    //   }
+    // }
+    // keyup(e){
+    //   let m=Math.floor((this.min+11)/12)*12;
+    //   let k=this.keycodes1.indexOf(e.keyCode);
+    //   if(k<0) {
+    //     k=this.keycodes2.indexOf(e.keyCode);
+    //     if(k>=0) k+=12;
+    //   }
+    //   if(k>=0){
+    //     k+=m;
+    //     this.currentKey=-1;
+    //     this.sendEventFromKey(0,k);
+    //     this.setNote(0,k);
+    //   }
+    // }
     pointerdown(ev){
       this.cv.focus();
       if(this.enable) {
@@ -1790,7 +1790,7 @@ ${this.basestyle}
         this.sendevent();
         this.redraw();
       }
-        
+
       let pointerup=(ev)=>{
         if(this.enable) {
           if(ev.touches)


### PR DESCRIPTION
### Why?
The previous logic was full of bugs 🐛🐛🐛
The most annoying of these was "sticky" keys, where notes would stay triggered when octave/detune was change while playing.
This was due to the webaudio-controls library event handling, as well as the nature of focus in the browser.
So I needed to create my own global keyboard listening instead, bypassing the native logic.

### New Logic
Each input type now uses the same logic to cut down on duplicate code.
Each key on the computer keyboard acts like a MIDI keyboard key.
Keyboard listening is now active no matter what is focused on the page (except text inputs).
Octave/detune controls now update notes in real-time, no more sticky keys! 😄
_Note: The webaudio-controls library had to be modified directly to deactivate the native keyboard logic._

### Global Octave Modifier
MS24 now includes a global octave slider, positioned beside the GUI keyboard.
This increases/decreases all octaves at once, allowing for 4 extra octaves to be reached.

### Arpeggiator
Arpeggiator functionality is now enabled!
This is done with three Tone.js Pattern Objects, one per synth.
GUI now includes switches for each oscillator's arpeggiator, as well as sliders for arp controls
Tone.Transport is now in use so that the arpeggiators have a timeline to play along.
GUI now includes a BPM knob beside the master gain knob, to adjust the Transport BPM.

### Extras / Other
Loads of code cleaned up & rearranged.
Lots of comments added/updated.
GUI keyboard keys increased from 49 (4 octaves + 1 semitone) to 61 (5 octaves + 1 semitone).
Fixed double keyDown bug.

### Known Bugs 🐛
While holding keys, if the octave is changed while the arp is off, and then arp is turned on, the arp will play the old octave.
