### PR TITLE
GUI rework

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,8 +454,8 @@
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
 										diameter="50"
-										min="-20"
-										max="0"
+										min="-10"
+										max="10"
 										value="0"
 										step="1"
 									></webaudio-knob>
@@ -763,8 +763,8 @@
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
 										diameter="50"
-										min="-20"
-										max="0"
+										min="-10"
+										max="10"
 										value="0"
 										step="1"
 									></webaudio-knob>
@@ -1054,8 +1054,8 @@
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
 										diameter="50"
-										min="-20"
-										max="0"
+										min="-10"
+										max="10"
 										value="0"
 										step="1"
 									></webaudio-knob>

--- a/index.html
+++ b/index.html
@@ -114,20 +114,20 @@
 				</div>
 			</div>
 		</div>
-		<div class="flex-col hidden w-min select-none bg-custom-black border border-orange-300 rounded-xl p-2" id="synth_container">
+		<div class="flex-col hidden w-min select-none bg-custom-black border border-orange-300 rounded-lg p-2" id="synth_container">
 			<div id="p5_canvas" class="self-center absolute"></div>
 			<!--********************-->
 			<!-- 	  TOP ROW 	    -->
 			<!--********************-->
-			<div class="flex justify-between w-full px-1 py-1 z-10 border border-gray-600 border-b-0 rounded-lg">
+			<div id="top_row_container" class="flex justify-between w-full px-1 py-1 z-10 border border-gray-600 border-b-0 rounded-lg">
 				<div class="w-[250px] flex">
 					<div class="flex self-center">
 						<button
 							id="settings_button"
 							class="
 							dropdownButton
-							border border-gray-300 rounded-xl
-							px-2 pb-0 self-center hover:bg-gray-600
+							border border-gray-300 rounded-lg
+							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
 							SETTINGS
 						</button>
@@ -135,15 +135,15 @@
 							id="settings_dropdown"
 							class="
 							dropdown_content
-							hidden absolute mt-8 w-[83px] z-10
-							bg-gray-600 border border-gray-400">
+							hidden absolute mt-8 w-[120px] z-10
+							bg-custom-black border border-white rounded-lg">
 							<a
-								id="home_button"
-								class="cursor-pointer flex p-2 hover:bg-gray-700"
-							>Welcome</a>
+								id="settings_home_button"
+								class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-bl-none rounded-br-none"
+							>Back Home</a>
 							<a
 								id="settings_theme_button"
-								class="cursor-pointer flex p-2 hover:bg-gray-700"
+								class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-tl-none rounded-tr-none"
 							>Toggle Theme</a>
 						</div>
 					</div>
@@ -154,8 +154,8 @@
 							id="presets_button"
 							class="
 							w-[75px]
-							border border-gray-300 rounded-xl
-							px-2 pb-0 self-center hover:bg-gray-600
+							border border-gray-300 rounded-lg
+							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
 							PRESETS
 						</button>
@@ -175,8 +175,8 @@
 						<button
 							id="random_preset_button"
 							class="w-[75px]
-							border border-gray-300 rounded-xl
-							px-2 pb-0 self-center hover:bg-gray-600
+							border border-gray-300 rounded-lg
+							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
 							RANDOM
 						</button>
@@ -185,7 +185,7 @@
 				<div class="w-[250px] flex justify-end">
 					<!--
 					<div class="flex flex-col p-1 border border-gray-600 rounded-lg">
-						<div class="border border-gray-500 border-b-0 rounded-lg rounded-br-none rounded-bl-none p-1 flex mr-1 h-min">
+						<div class="border border-gray-600 border-b-0 rounded-lg rounded-br-none rounded-bl-none p-1 flex mr-1 h-min">
 							<p id="master_gain_label_h" class="text-sm self-center w-[30px]">Vol</p>
 							<webaudio-knob
 								id="master_gain_h"
@@ -201,10 +201,10 @@
 								id="master_gain_readout_h"
 								link="master_gain_h"
 								fontSize="10"
-								class="border border-gray-500 self-center ml-2"
+								class="border border-gray-600 self-center ml-2"
 							></webaudio-param>
 						</div>
-						<div class="border border-gray-500 border-t-0 rounded-lg rounded-tr-none rounded-tl-none p-1 flex mr-1 h-min">
+						<div class="border border-gray-600 border-t-0 rounded-lg rounded-tr-none rounded-tl-none p-1 flex mr-1 h-min">
 							<p id="master_bpm_label_h" class="text-sm self-center w-[30px]">BPM</p>
 							<webaudio-knob
 								id="master_bpm_h"
@@ -220,13 +220,13 @@
 								id="master_bpm_readout_h"
 								link="master_bpm_h"
 								fontSize="10"
-								class="border border-gray-500 self-center ml-2"
+								class="border border-gray-600 self-center ml-2"
 							></webaudio-param>
 						</div>
 					</div>
 					-->
 					<div class="flex p-1 border border-gray-600 rounded-lg">
-						<div class="border border-gray-500 rounded-xl p-1 flex flex-col mr-1 w-[50px]">
+						<div class="border border-gray-600 rounded-lg p-1 flex flex-col mr-1 w-[50px]">
 							<p id="master_bpm_label" class="text-center text-sm">BPM</p>
 							<webaudio-knob
 								id="master_bpm"
@@ -242,10 +242,10 @@
 								id="master_bpm_readout"
 								link="master_bpm"
 								fontSize="10"
-								class="self-center border border-gray-500 mt-1"
+								class="self-center border border-gray-600 mt-1"
 							></webaudio-param>
 						</div>
-						<div class="border border-gray-500 rounded-xl p-1 flex flex-col w-[50px]">
+						<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[50px]">
 							<p id="master_gain_label" class="text-center text-sm">Gain</p>
 							<webaudio-knob
 								id="master_gain"
@@ -261,7 +261,7 @@
 								id="master_gain_readout"
 								link="master_gain"
 								fontSize="10"
-								class="self-center border border-gray-500 mt-1"
+								class="self-center border border-gray-600 mt-1"
 							></webaudio-param>
 						</div>
 					</div>
@@ -272,7 +272,7 @@
 				<!--********************-->
 				<!--	  ROW ONE 	    -->
 				<!--********************-->
-				<div class="flex z-10">
+				<div class="flex z-0">
 					<!--********************-->
 					<!--	OSCILLATOR A	-->
 					<!--********************-->
@@ -303,7 +303,7 @@
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_a_voices"
@@ -318,12 +318,12 @@
 										<webaudio-param
 											id="osc_a_voices_readout"
 											link="osc_a_voices"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_a_spread"
@@ -338,12 +338,12 @@
 										<webaudio-param
 											id="osc_a_spread_readout"
 											link="osc_a_spread"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">FM</p>
 										<webaudio-knob
 											id="osc_a_fm"
@@ -358,12 +358,12 @@
 										<webaudio-param
 											id="osc_a_fm_readout"
 											link="osc_a_fm"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Depth</p>
 										<webaudio-knob
 											id="osc_a_fm_depth"
@@ -378,12 +378,12 @@
 										<webaudio-param
 											id="osc_a_fm_depth_readout"
 											link="osc_a_fm_depth"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_a_fm_shape"
@@ -399,7 +399,7 @@
 										<webaudio-param
 											id="osc_a_fm_shape_readout"
 											link="osc_a_fm_shape"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
@@ -407,7 +407,7 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_a_octave"
@@ -427,7 +427,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_a_semi"
@@ -447,7 +447,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_a_volume"
@@ -467,7 +467,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_a_shape"
@@ -492,7 +492,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_a_attack"
@@ -512,7 +512,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_a_decay"
@@ -532,7 +532,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_a_sustain"
@@ -552,7 +552,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_a_release"
@@ -574,7 +574,7 @@
 								</div>
 							</div>
 							<div id="osc_a_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_a_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="osc_a_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -612,7 +612,7 @@
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_b_voices"
@@ -627,12 +627,12 @@
 										<webaudio-param
 											id="osc_b_voices_readout"
 											link="osc_b_voices"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_b_spread"
@@ -647,12 +647,12 @@
 										<webaudio-param
 											id="osc_b_spread_readout"
 											link="osc_b_spread"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">FM</p>
 										<webaudio-knob
 											id="osc_b_fm"
@@ -667,12 +667,12 @@
 										<webaudio-param
 											id="osc_b_fm_readout"
 											link="osc_b_fm"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Depth</p>
 										<webaudio-knob
 											id="osc_b_fm_depth"
@@ -687,12 +687,12 @@
 										<webaudio-param
 											id="osc_b_fm_depth_readout"
 											link="osc_b_fm_depth"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_b_fm_shape"
@@ -708,7 +708,7 @@
 										<webaudio-param
 											id="osc_b_fm_shape_readout"
 											link="osc_b_fm_shape"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
@@ -716,7 +716,7 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_b_octave"
@@ -736,7 +736,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_b_semi"
@@ -756,7 +756,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_b_volume"
@@ -776,7 +776,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_b_shape"
@@ -802,7 +802,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_b_attack"
@@ -822,7 +822,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_b_decay"
@@ -842,7 +842,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_b_sustain"
@@ -862,7 +862,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_b_release"
@@ -884,7 +884,7 @@
 								</div>
 							</div>
 							<div id="osc_b_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_b_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="osc_b_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -923,7 +923,7 @@
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_c_voices"
@@ -938,12 +938,12 @@
 										<webaudio-param
 											id="osc_c_voices_readout"
 											link="osc_c_voices"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_c_spread"
@@ -958,12 +958,12 @@
 										<webaudio-param
 											id="osc_c_spread_readout"
 											link="osc_c_spread"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">AM</p>
 										<webaudio-knob
 											id="osc_c_am"
@@ -978,12 +978,12 @@
 										<webaudio-param
 											id="osc_c_am_readout"
 											link="osc_c_am"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
+									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_c_am_shape"
@@ -999,7 +999,7 @@
 										<webaudio-param
 											id="osc_c_am_shape_readout"
 											link="osc_c_am_shape"
-											class="self-center border border-gray-500 mt-1"
+											class="self-center border border-gray-600 mt-1"
 											fontSize="10"
 											width="30"
 										></webaudio-param>
@@ -1007,7 +1007,7 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_c_octave"
@@ -1027,7 +1027,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_c_semi"
@@ -1047,7 +1047,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_c_volume"
@@ -1067,7 +1067,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_c_shape"
@@ -1093,7 +1093,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_c_attack"
@@ -1113,7 +1113,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_c_decay"
@@ -1133,7 +1133,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_c_sustain"
@@ -1153,7 +1153,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_c_release"
@@ -1175,7 +1175,7 @@
 								</div>
 							</div>
 							<div id="osc_c_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_c_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="osc_c_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1191,18 +1191,21 @@
 					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
 						<!--left-->
 						<div class="flex flex-col justify-between mr-1">
-							<div class="flex p-1">
-								<webaudio-switch
-									id="filter_switch"
-									class="control toggleControl self-center pr-1"
-									colors="#A9DC76;#2C292D;#D9D9D9"
-									diameter="30"
-									value="1"
-								></webaudio-switch>
-								<p class="font-inika self-center">FILTER</p>
+							<div class="h-[98px] mb-1">
+								<div class="flex p-1">
+									<webaudio-switch
+										id="filter_switch"
+										class="control toggleControl self-center pr-1"
+										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="30"
+										value="1"
+									></webaudio-switch>
+									<p class="font-inika self-center">FILTER</p>
+								</div>
 							</div>
+
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Cutoff</p>
 									<webaudio-knob
 										id="filter_cutoff"
@@ -1222,7 +1225,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="filter_resonance_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div id="filter_resonance_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
 									<webaudio-knob
 										id="filter_resonance"
@@ -1242,7 +1245,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Rolloff</p>
 									<webaudio-slider
 										id="filter_rolloff"
@@ -1263,7 +1266,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Type</p>
 									<webaudio-slider
 										id="filter_type"
@@ -1289,9 +1292,9 @@
 						</div>
 						<!--right-->
 						<div class="flex flex-col justify-center">
-							<div class="self-center border border-gray-600 flex rounded-lg p-1 h-[104px]">
-								<div class="border border-gray-500 rounded-xl p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center">A</p>
+							<div class="self-center border border-gray-600 flex justify-around rounded-lg p-1 mb-1 w-[222px] h-[98px]">
+								<div class="p-0.5 w-min flex flex-col justify-center">
+									<p class="font-light text-sm self-center w-max">Send A</p>
 									<webaudio-switch
 										id="osc_a_filter_switch"
 										class="control toggleControl self-center"
@@ -1300,8 +1303,8 @@
 										value="1"
 									></webaudio-switch>
 								</div>
-								<div class="border border-gray-500 rounded-xl p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center">B</p>
+								<div class="p-0.5 w-min flex flex-col justify-center">
+									<p class="font-light text-sm self-center w-max">Send B</p>
 									<webaudio-switch
 										id="osc_b_filter_switch"
 										class="control toggleControl self-center"
@@ -1310,8 +1313,8 @@
 										value="1"
 									></webaudio-switch>
 								</div>
-								<div class="border border-gray-500 rounded-xl p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center">C</p>
+								<div class="p-0.5 w-min flex flex-col justify-center">
+									<p class="font-light text-sm self-center w-max">Send C</p>
 									<webaudio-switch
 										id="osc_c_filter_switch"
 										class="control toggleControl self-center"
@@ -1322,7 +1325,7 @@
 								</div>
 							</div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="filter_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="filter_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1350,7 +1353,7 @@
 									&nbsp;
 									<select
 										id="lfo_selector"
-										class="control font-light bg-custom-black border border-gray-600 rounded-xl p-1 pl-3"
+										class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
 										autocomplete="off"
 									>
 										<option value="FilterFrequency" selected="selected">Filter Frequency</option>
@@ -1361,7 +1364,7 @@
 								</label>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Grid</p>
 									<webaudio-knob
 										id="lfo_grid"
@@ -1382,7 +1385,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Min</p>
 									<webaudio-knob
 										id="lfo_min"
@@ -1402,7 +1405,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Max</p>
 									<webaudio-knob
 										id="lfo_max"
@@ -1422,7 +1425,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="lfo_shape"
@@ -1450,7 +1453,7 @@
 						<div>
 							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="lfo_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="lfo_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1477,7 +1480,7 @@
 									&nbsp;
 									<select
 										id="fx_selector"
-										class="control font-light bg-custom-black border border-gray-600 rounded-xl p-1 pl-3"
+										class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
 										autocomplete="off"
 									>
 										<option value="Distortion" selected="selected">Distortion</option>
@@ -1493,7 +1496,7 @@
 								</label>
 							</div>
 							<div class="flex w-[372px]">
-								<div id="fx_param1_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div id="fx_param1_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param1_label" class="font-light self-center mb-0.5">Intensity</p>
 									<webaudio-knob
 										id="fx_param1"
@@ -1513,7 +1516,7 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="fx_param2_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div id="fx_param2_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param2_label" class="font-light self-center mb-0.5">Oversample</p>
 									<webaudio-knob
 										id="fx_param2"
@@ -1533,7 +1536,7 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="fx_param3_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
+								<div id="fx_param3_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param3_label" class="font-light self-center mb-0.5">Mix</p>
 									<webaudio-knob
 										id="fx_param3"
@@ -1553,7 +1556,7 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div id="fx_param4_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] hidden">
+								<div id="fx_param4_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] hidden">
 									<p id="fx_param4_label" class="font-light self-center mb-0.5">Mix</p>
 									<webaudio-knob
 										id="fx_param4"
@@ -1579,7 +1582,7 @@
 						<div class="flex flex-col justify-center">
 							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="fx_canvas" width="212" height="100"></canvas>
+								<canvas class="self-center" id="fx_canvas" width="212" height="102"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1591,7 +1594,7 @@
 					<div class="w-full flex justify-between z-10">
 						<div class="flex">
 							<div class="flex flex-col mr-1 z-10">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light text-sm self-center mb-0.5">Pattern</p>
 									<webaudio-slider
 										id="arp_pattern"
@@ -1614,7 +1617,7 @@
 								</div>
 							</div>
 							<div class="flex flex-col mr-1 z-10">
-								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 									<p class="font-light text-sm self-center mb-0.5">Speed</p>
 									<webaudio-slider
 										id="arp_speed"
@@ -1636,9 +1639,8 @@
 									></webaudio-param>
 								</div>
 							</div>
-						</div>
-						<div class="flex flex-col z-10">
-							<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
+							<div class="p-1 flex flex-col w-[90px] mr-1"></div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
 								<p class="font-light text-sm self-center mb-0.5">Octave</p>
 								<webaudio-slider
 									id="master_octave"
@@ -1654,18 +1656,19 @@
 								<webaudio-param
 									id="master_octave_readout"
 									link="master_octave"
-									class="self-center border border-gray-500 mt-1"
+									class="self-center border border-gray-600 mt-1"
 									fontSize="10"
 									width="60"
 								></webaudio-param>
 							</div>
 						</div>
 					</div>
-					<div class="border border-gray-500 rounded-xl self-center p-2 mx-1 z-10">
+					<div class="border border-gray-600 rounded-lg self-center p-2 mx-1 z-10">
 						<webaudio-keyboard
 							id="keyboard"
 							keys="61"
 							height="85"
+							width="510"
 							class="self-center"
 						></webaudio-keyboard>
 					</div>
@@ -1683,63 +1686,41 @@
 					</div>
 				</div>
 			</div>
-			<div id="presets_container" class="hidden">
-				<div class="mt-2 flex justify-end">
-					<a
-						id="preset_disk_load_button"
-						class="cursor-pointer flex p-2 bg-gray-700 rounded-lg"
-					>Load from disk</a>
-					<input id="preset_file_input" class="hidden" type='file' />
-				</div>
+			<div id="presets_container" class="hidden w-[1285px] border border-gray-600 border-t-0 rounded-xl rounded-tl-none rounded-tr-none p-1">
 				<!--Presets table: name/type/author/rating/load-->
 				<table id="presets_table" class="table-auto w-full">
 					<thead>
-						<tr class="text-left">
-							<th>Name</th>
-							<th>Type</th>
-							<th>Author</th>
-							<th>Rating</th>
-							<th class="text-right"></th>
+						<tr class="text-left font-inika">
+							<th class="font-light">Name</th>
+							<th class="font-light">Type</th>
+							<th class="font-light">Author</th>
+							<th class="font-light">Rating</th>
+							<th></th>
 						</tr>
 					</thead>
 					<tbody id="preset_save_body">
 						<tr id="preset_save_row">
-							<td><label for="preset_name_input"></label><input id="preset_name_input" class="bg-gray-700 text-gray-300 rounded-lg p-1" type="text" placeholder="Preset name" value="Init"></td>
-							<td><label for="preset_type_input"></label><input id="preset_type_input" class="bg-gray-700 text-gray-300 rounded-lg p-1" type="text" placeholder="Preset type" value="Default"></td>
-							<td><label for="preset_author_input"></label><input id="preset_author_input" class="bg-gray-700 text-gray-300 rounded-lg p-1" type="text" placeholder="Preset author" value="MangoSynth"></td>
-							<td><label for="preset_rating_input"></label><input id="preset_rating_input" class="bg-gray-700 text-gray-300 rounded-lg p-1" type="text" placeholder="Preset rating" value="0"></td>
-							<td class="text-right">
-								<button id="preset_save_button" class="bg-gray-700 text-gray-300 rounded-lg p-1">Save</button>
-							</td>
-							<td class="text-right">
-								<button id="preset_download_button" class="bg-gray-700 text-gray-300 rounded-lg p-1">Download</button>
+							<td><label for="preset_name_input"></label><input id="preset_name_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset name" value="Init"></td>
+							<td><label for="preset_type_input"></label><input id="preset_type_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset type" value="Default"></td>
+							<td><label for="preset_author_input"></label><input id="preset_author_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset author" value="MangoSynth"></td>
+							<td><label for="preset_rating_input"></label><input id="preset_rating_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset rating" value="0"></td>
+							<td class="flex justify-end mb-1">
+								<button id="preset_save_button" class="border border-blue-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center mr-1">Save Preset</button>
+								<button id="preset_download_button" class="border border-green-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center">Download Preset</button>
 							</td>
 						</tr>
 					</tbody>
 					<tbody id="presets_table_body">
-						<tr>
-							<td>Placeholder name!</td>
-							<td>Placeholder type!</td>
-							<td>Placeholder author!</td>
-							<td>Placeholder rating!</td>
-							<td class="text-right"><button class="bg-gray-700 text-gray-300 rounded-lg p-1">Load Preset</button></td>
-						</tr>
-						<tr class="bg-black">
-							<td>Placeholder name!</td>
-							<td>Placeholder type!</td>
-							<td>Placeholder author!</td>
-							<td>Placeholder rating!</td>
-							<td class="text-right"><button class="bg-gray-700 text-gray-300 rounded-lg p-1">Load Preset</button></td>
-						</tr>
-						<tr>
-							<td>Placeholder name!</td>
-							<td>Placeholder type!</td>
-							<td>Placeholder author!</td>
-							<td>Placeholder rating!</td>
-							<td class="text-right"><button class="bg-gray-700 text-gray-300 rounded-lg p-1">Load Preset</button></td>
-						</tr>
+						<!--Presets auto-injected here-->
 					</tbody>
 				</table>
+				<hr class="mb-4 mt-4"/>
+				<div class="mb-2  flex justify-center">
+					<a id="preset_disk_load_button" class="flex cursor-pointer text-sm border border-gray-500 hover:border-white rounded-lg p-2 transition-all">
+						Load from disk
+					</a>
+					<input id="preset_file_input" class="hidden" type='file' />
+				</div>
 			</div>
 		</div>
 	</main>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 			<!--********************-->
 			<!-- 	  TOP ROW 	    -->
 			<!--********************-->
-			<div class="flex justify-between border border-gray-700 w-full p-1 z-10">
+			<div class="flex justify-between w-full px-1 py-1 z-10 border border-gray-600 border-b-0 rounded-lg">
 				<div class="w-[250px] flex">
 					<div class="flex self-center">
 						<button
@@ -183,55 +183,100 @@
 					</div>
 				</div>
 				<div class="w-[250px] flex justify-end">
-					<div class="border border-gray-500 rounded-xl p-1 w-min flex flex-col mr-1">
-						<p id="master_bpm_label" class="text-center">BPM</p>
-						<webaudio-knob
-							id="master_bpm"
-							class="control masterControl self-center"
-							colors="#FFFFFF;#2C292D;#D9D9D9"
-							diameter="40"
-							min="1"
-							max="600"
-							value="120"
-							step="1"
-						></webaudio-knob>
-						<webaudio-param
-							id="master_bpm_readout"
-							link="master_bpm"
-							fontSize="14"
-							class="self-center border border-gray-500 mt-1"
-						></webaudio-param>
+					<!--
+					<div class="flex flex-col p-1 border border-gray-600 rounded-lg">
+						<div class="border border-gray-500 border-b-0 rounded-lg rounded-br-none rounded-bl-none p-1 flex mr-1 h-min">
+							<p id="master_gain_label_h" class="text-sm self-center w-[30px]">Vol</p>
+							<webaudio-knob
+								id="master_gain_h"
+								class="control masterControl ml-1"
+								colors="#FFFFFF;#2C292D;#D9D9D9"
+								diameter="30"
+								min="0"
+								max="2"
+								value="1"
+								step=".01"
+							></webaudio-knob>
+							<webaudio-param
+								id="master_gain_readout_h"
+								link="master_gain_h"
+								fontSize="10"
+								class="border border-gray-500 self-center ml-2"
+							></webaudio-param>
+						</div>
+						<div class="border border-gray-500 border-t-0 rounded-lg rounded-tr-none rounded-tl-none p-1 flex mr-1 h-min">
+							<p id="master_bpm_label_h" class="text-sm self-center w-[30px]">BPM</p>
+							<webaudio-knob
+								id="master_bpm_h"
+								class="control masterControl ml-1"
+								colors="#FFFFFF;#2C292D;#D9D9D9"
+								diameter="30"
+								min="1"
+								max="600"
+								value="120"
+								step="1"
+							></webaudio-knob>
+							<webaudio-param
+								id="master_bpm_readout_h"
+								link="master_bpm_h"
+								fontSize="10"
+								class="border border-gray-500 self-center ml-2"
+							></webaudio-param>
+						</div>
 					</div>
-					<div class="border border-gray-500 rounded-xl p-1 w-min flex flex-col">
-						<p id="master_gain_label" class="text-center">Master</p>
-						<webaudio-knob
-							id="master_gain"
-							class="control masterControl self-center"
-							colors="#FFFFFF;#2C292D;#D9D9D9"
-							diameter="40"
-							min="0"
-							max="2"
-							value="1"
-							step="0.01"
-						></webaudio-knob>
-						<webaudio-param
-							id="master_gain_readout"
-							link="master_gain"
-							fontSize="14"
-							class="self-center border border-gray-500 mt-1"
-						></webaudio-param>
+					-->
+					<div class="flex p-1 border border-gray-600 rounded-lg">
+						<div class="border border-gray-500 rounded-xl p-1 flex flex-col mr-1 w-[50px]">
+							<p id="master_bpm_label" class="text-center text-sm">BPM</p>
+							<webaudio-knob
+								id="master_bpm"
+								class="control masterControl self-center"
+								colors="#FFFFFF;#2C292D;#D9D9D9"
+								diameter="30"
+								min="1"
+								max="600"
+								value="120"
+								step="1"
+							></webaudio-knob>
+							<webaudio-param
+								id="master_bpm_readout"
+								link="master_bpm"
+								fontSize="10"
+								class="self-center border border-gray-500 mt-1"
+							></webaudio-param>
+						</div>
+						<div class="border border-gray-500 rounded-xl p-1 flex flex-col w-[50px]">
+							<p id="master_gain_label" class="text-center text-sm">Gain</p>
+							<webaudio-knob
+								id="master_gain"
+								class="control masterControl self-center"
+								colors="#FFFFFF;#2C292D;#D9D9D9"
+								diameter="30"
+								min="0"
+								max="2"
+								value="1"
+								step="0.01"
+							></webaudio-knob>
+							<webaudio-param
+								id="master_gain_readout"
+								link="master_gain"
+								fontSize="10"
+								class="self-center border border-gray-500 mt-1"
+							></webaudio-param>
+						</div>
 					</div>
+
 				</div>
 			</div>
-			<div id="synth_body">
+			<div id="synth_body" class="flex flex-col">
 				<!--********************-->
 				<!--	  ROW ONE 	    -->
 				<!--********************-->
-				<div class="flex border border-gray-700 p-1 z-10">
+				<div class="flex z-10">
 					<!--********************-->
 					<!--	OSCILLATOR A	-->
 					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
 						<!--left-->
 						<div class="flex flex-col justify-between mr-1">
 							<div class="flex justify-between mb-1">
@@ -244,7 +289,7 @@
 											diameter="30"
 											value="1"
 										></webaudio-switch>
-										<p class="font-inika font-bold self-center">OSC A</p>
+										<p class="font-inika self-center">OSC A</p>
 									</div>
 									<div class="flex p-1">
 										<webaudio-switch
@@ -254,11 +299,11 @@
 											diameter="30"
 											value="0"
 										></webaudio-switch>
-										<p id="arp_a_label" class="font-inika font-bold ml-1">ARP</p>
+										<p id="arp_a_label" class="font-inika ml-1">ARP</p>
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_a_voices"
@@ -278,7 +323,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_a_spread"
@@ -298,7 +343,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">FM</p>
 										<webaudio-knob
 											id="osc_a_fm"
@@ -318,7 +363,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Depth</p>
 										<webaudio-knob
 											id="osc_a_fm_depth"
@@ -338,7 +383,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_a_fm_shape"
@@ -362,12 +407,13 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_a_octave"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-3"
 										max="3"
 										value="0"
@@ -381,12 +427,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_a_semi"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-12"
 										max="12"
 										value="0"
@@ -400,12 +447,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_a_volume"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-20"
 										max="0"
 										value="0"
@@ -419,12 +467,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_a_shape"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="3"
 										direction="vert"
@@ -443,7 +492,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_a_attack"
@@ -463,7 +512,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_a_decay"
@@ -483,7 +532,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_a_sustain"
@@ -503,7 +552,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px]">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_a_release"
@@ -525,18 +574,18 @@
 								</div>
 							</div>
 							<div id="osc_a_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_a_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="osc_a_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
 					<!--********************-->
 					<!--	  MIDDLE		-->
 					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 w-[61px] mx-1 z-10"></div>
+					<div class="self-center w-[61px] mx-1 z-10"></div>
 					<!--********************-->
 					<!--	OSCILLATOR B	-->
 					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
 						<!--left-->
 						<div class="flex flex-col justify-between mr-1">
 							<div class="flex justify-between mb-1">
@@ -549,7 +598,7 @@
 											diameter="30"
 											value="0"
 										></webaudio-switch>
-										<p class="font-inika font-bold self-center">OSC B</p>
+										<p class="font-inika self-center">OSC B</p>
 									</div>
 									<div class="flex p-1">
 										<webaudio-switch
@@ -559,11 +608,11 @@
 											diameter="30"
 											value="0"
 										></webaudio-switch>
-										<p id="arp_b_label" class="font-inika font-bold ml-1">ARP</p>
+										<p id="arp_b_label" class="font-inika ml-1">ARP</p>
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_b_voices"
@@ -583,7 +632,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_b_spread"
@@ -603,7 +652,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">FM</p>
 										<webaudio-knob
 											id="osc_b_fm"
@@ -623,7 +672,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Depth</p>
 										<webaudio-knob
 											id="osc_b_fm_depth"
@@ -643,7 +692,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_b_fm_shape"
@@ -667,12 +716,13 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_b_octave"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-3"
 										max="3"
 										value="1"
@@ -686,12 +736,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_b_semi"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-12"
 										max="12"
 										value="0"
@@ -705,12 +756,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_b_volume"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-20"
 										max="0"
 										value="0"
@@ -724,12 +776,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_b_shape"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="3"
 										value="1"
@@ -749,7 +802,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_b_attack"
@@ -769,7 +822,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_b_decay"
@@ -789,7 +842,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_b_sustain"
@@ -809,7 +862,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px]">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_b_release"
@@ -831,7 +884,7 @@
 								</div>
 							</div>
 							<div id="osc_b_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_b_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="osc_b_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
@@ -839,11 +892,11 @@
 				<!--********************-->
 				<!--	  ROW TWO 	    -->
 				<!--********************-->
-				<div class="flex border border-gray-700 p-1 z-10">
+				<div class="flex z-10">
 					<!--********************-->
 					<!--  SUB OSCILLATOR	-->
 					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
 						<!--left-->
 						<div class="flex flex-col justify-between mr-1">
 							<div class="flex justify-between mb-1">
@@ -856,7 +909,7 @@
 											diameter="30"
 											value="0"
 										></webaudio-switch>
-										<p class="font-inika font-bold self-center">SUB OSC</p>
+										<p class="font-inika self-center">SUB OSC</p>
 									</div>
 									<div class="flex p-1">
 										<webaudio-switch
@@ -866,11 +919,11 @@
 											diameter="30"
 											value="0"
 										></webaudio-switch>
-										<p id="arp_c_label" class="font-inika font-bold ml-1">ARP</p>
+										<p id="arp_c_label" class="font-inika ml-1">ARP</p>
 									</div>
 								</div>
 								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Voices</p>
 										<webaudio-knob
 											id="osc_c_voices"
@@ -890,7 +943,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Spread</p>
 										<webaudio-knob
 											id="osc_c_spread"
@@ -910,7 +963,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end mr-1 w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end mr-1 w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">AM</p>
 										<webaudio-knob
 											id="osc_c_am"
@@ -930,7 +983,7 @@
 											width="30"
 										></webaudio-param>
 									</div>
-									<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col self-end w-[50px]">
+									<div class="border border-gray-500 rounded-xl py-1 flex flex-col self-end w-[50px]">
 										<p class="font-light text-sm self-center mb-0.5">Shape</p>
 										<webaudio-knob
 											id="osc_c_am_shape"
@@ -954,12 +1007,13 @@
 								</div>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Octave</p>
 									<webaudio-knob
 										id="osc_c_octave"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="3"
 										value="0"
@@ -973,12 +1027,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Detune</p>
 									<webaudio-knob
 										id="osc_c_semi"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-12"
 										max="12"
 										value="0"
@@ -992,12 +1047,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Volume</p>
 									<webaudio-knob
 										id="osc_c_volume"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										diameter="50"
 										min="-20"
 										max="0"
 										value="0"
@@ -1011,12 +1067,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="osc_c_shape"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="3"
 										value="2"
@@ -1036,7 +1093,7 @@
 						<!--right-->
 						<div class="flex flex-col">
 							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">ATK</p>
 									<webaudio-knob
 										id="osc_c_attack"
@@ -1056,7 +1113,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">DEC</p>
 									<webaudio-knob
 										id="osc_c_decay"
@@ -1076,7 +1133,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px] mr-1">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px] mr-1">
 									<p class="font-light text-sm self-center mb-0.5">SUS</p>
 									<webaudio-knob
 										id="osc_c_sustain"
@@ -1096,7 +1153,7 @@
 										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-500 rounded-xl py-1 w-min flex flex-col w-[50px]">
+								<div class="border border-gray-500 rounded-xl py-1 flex flex-col w-[50px]">
 									<p class="font-light text-sm self-center mb-0.5">REL</p>
 									<webaudio-knob
 										id="osc_c_release"
@@ -1118,20 +1175,20 @@
 								</div>
 							</div>
 							<div id="osc_c_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_c_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="osc_c_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
 					<!--********************-->
 					<!--   FM VISUALISER 	-->
 					<!--********************-->
-					<div class="self-center border border-gray-600 flex rounded-lg p-1 mx-1 h-[202px] z-10">
+					<div class="self-center border border-gray-600 flex rounded-lg p-1 mx-1 z-10">
 						<canvas class="self-center" id="fm_canvas" width="51" height="50"></canvas>
 					</div>
 					<!--********************-->
 					<!--    MULTI FILTER    -->
 					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
 						<!--left-->
 						<div class="flex flex-col justify-between mr-1">
 							<div class="flex p-1">
@@ -1142,15 +1199,16 @@
 									diameter="30"
 									value="1"
 								></webaudio-switch>
-								<p class="font-inika font-bold self-center">FILTER</p>
+								<p class="font-inika self-center">FILTER</p>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Cutoff</p>
 									<webaudio-knob
 										id="filter_cutoff"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="5"
 										max="10000"
 										value="5000"
@@ -1164,12 +1222,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="filter_resonance_group" class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div id="filter_resonance_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
 									<webaudio-knob
 										id="filter_resonance"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="1"
 										max="10"
 										value="0"
@@ -1183,12 +1242,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Rolloff</p>
 									<webaudio-slider
 										id="filter_rolloff"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="3"
 										step="1"
@@ -1203,12 +1263,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Type</p>
 									<webaudio-slider
 										id="filter_type"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="6"
 										step="1"
@@ -1228,7 +1289,7 @@
 						</div>
 						<!--right-->
 						<div class="flex flex-col justify-center">
-							<div class="self-center border border-gray-600 flex rounded-lg p-1 h-[100px]">
+							<div class="self-center border border-gray-600 flex rounded-lg p-1 h-[104px]">
 								<div class="border border-gray-500 rounded-xl p-0.5 w-min flex flex-col justify-center">
 									<p class="font-light text-sm self-center">A</p>
 									<webaudio-switch
@@ -1261,7 +1322,7 @@
 								</div>
 							</div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="filter_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="filter_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1269,7 +1330,7 @@
 				<!--********************-->
 				<!--	 ROW THREE 	    -->
 				<!--********************-->
-				<div class="flex border border-gray-700 p-1 z-10">
+				<div class="flex z-10">
 					<!--********************-->
 					<!--   LOW FREQ OSC 	-->
 					<!--********************-->
@@ -1284,7 +1345,7 @@
 									diameter="30"
 									value="0"
 								></webaudio-switch>
-								<label class="font-inika font-bold self-center" for="lfo_selector">
+								<label class="font-inika self-center" for="lfo_selector">
 									LFO
 									&nbsp;
 									<select
@@ -1300,12 +1361,13 @@
 								</label>
 							</div>
 							<div class="flex">
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Grid</p>
 									<webaudio-knob
 										id="lfo_grid"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="9"
 										value="5"
@@ -1320,12 +1382,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Min</p>
 									<webaudio-knob
 										id="lfo_min"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="10000"
 										value="0"
@@ -1339,12 +1402,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p class="font-light self-center mb-0.5">Max</p>
 									<webaudio-knob
 										id="lfo_max"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="10000"
 										value="1000"
@@ -1358,12 +1422,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px]">
+								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
 									<p class="font-light self-center mb-0.5">Shape</p>
 									<webaudio-slider
 										id="lfo_shape"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										height="50"
 										min="0"
 										max="3"
 										step="1"
@@ -1383,16 +1448,16 @@
 						</div>
 						<!--right-->
 						<div>
-							<div class="self-center flex rounded-lg p-1 h-[98px] mb-1"></div>
+							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="lfo_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="lfo_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
 					<!--************-->
 					<!--   MIDDLE 	-->
 					<!--************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 w-[61px] mx-1 z-10"></div>
+					<div class="self-center w-[61px] mx-1 z-10"></div>
 					<!--********************-->
 					<!--     MULTI FX       -->
 					<!--********************-->
@@ -1407,7 +1472,7 @@
 									diameter="30"
 									value="1"
 								></webaudio-switch>
-								<label class="font-inika font-bold self-center" for="fx_selector">
+								<label class="font-inika self-center" for="fx_selector">
 									FX
 									&nbsp;
 									<select
@@ -1428,12 +1493,13 @@
 								</label>
 							</div>
 							<div class="flex w-[372px]">
-								<div id="fx_param1_group" class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div id="fx_param1_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param1_label" class="font-light self-center mb-0.5">Intensity</p>
 									<webaudio-knob
 										id="fx_param1"
 										class="control mainControl1 self-center"
 										colors="#FF6188;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="20"
 										value="0"
@@ -1447,12 +1513,13 @@
 										class="self-center border border-pink-800 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="fx_param2_group" class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div id="fx_param2_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param2_label" class="font-light self-center mb-0.5">Oversample</p>
 									<webaudio-knob
 										id="fx_param2"
 										class="control mainControl2 self-center"
 										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="2"
 										value="0"
@@ -1466,12 +1533,13 @@
 										class="self-center border border-green-700 mt-1"
 									></webaudio-param>
 								</div>
-								<div id="fx_param3_group" class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] mr-1">
+								<div id="fx_param3_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] mr-1">
 									<p id="fx_param3_label" class="font-light self-center mb-0.5">Mix</p>
 									<webaudio-knob
 										id="fx_param3"
 										class="control mainControl3 self-center"
 										colors="#FFD866;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="1"
 										step=".01"
@@ -1485,12 +1553,13 @@
 										width="60"
 									></webaudio-param>
 								</div>
-								<div id="fx_param4_group" class="border border-gray-600 rounded-xl p-1 w-min flex flex-col w-[90px] hidden">
+								<div id="fx_param4_group" class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px] hidden">
 									<p id="fx_param4_label" class="font-light self-center mb-0.5">Mix</p>
 									<webaudio-knob
 										id="fx_param4"
 										class="control mainControl4 self-center"
 										colors="#78DCE8;#2C292D;#D9D9D9"
+										diameter="50"
 										min="0"
 										max="1"
 										step=".01"
@@ -1508,9 +1577,9 @@
 						</div>
 						<!--right-->
 						<div class="flex flex-col justify-center">
-							<div class="self-center flex rounded-lg p-1 h-[98px] mb-1"></div>
+							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="fx_canvas" width="212" height="122"></canvas>
+								<canvas class="self-center" id="fx_canvas" width="212" height="100"></canvas>
 							</div>
 						</div>
 					</div>
@@ -1518,12 +1587,12 @@
 				<!--********************-->
 				<!-- 	  KEYBOARD 	    -->
 				<!--********************-->
-				<div class="flex justify-center border border-gray-700 p-1 z-10">
+				<div class="flex justify-center p-1 z-10 border border-gray-600 border-t-0 rounded-lg">
 					<div class="w-full flex justify-between z-10">
 						<div class="flex">
 							<div class="flex flex-col mr-1 z-10">
 								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Pattern</p>
+									<p class="font-light text-sm self-center mb-0.5">Pattern</p>
 									<webaudio-slider
 										id="arp_pattern"
 										class="control mainControl4 self-center"
@@ -1532,21 +1601,21 @@
 										max="8"
 										value="0"
 										direction="vert"
-										height="85"
+										height="50"
 										conv="['up','down','upDown','downUp','alternateUp','alternateDown','random','randomOnce','randomWalk'][x]"
 									></webaudio-slider>
 									<webaudio-param
 										id="arp_pattern_readout"
 										link="arp_pattern"
 										class="self-center border border-violet-900 mt-1"
-										fontSize="14"
+										fontSize="10"
 										width="60"
 									></webaudio-param>
 								</div>
 							</div>
 							<div class="flex flex-col mr-1 z-10">
 								<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Speed</p>
+									<p class="font-light text-sm self-center mb-0.5">Speed</p>
 									<webaudio-slider
 										id="arp_speed"
 										class="control mainControl4 self-center"
@@ -1555,14 +1624,14 @@
 										max="6"
 										value="3"
 										direction="vert"
-										height="85"
+										height="50"
 										conv="['1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
 									></webaudio-slider>
 									<webaudio-param
 										id="arp_speed_readout"
 										link="arp_speed"
 										class="self-center border border-violet-900 mt-1"
-										fontSize="14"
+										fontSize="10"
 										width="60"
 									></webaudio-param>
 								</div>
@@ -1570,7 +1639,7 @@
 						</div>
 						<div class="flex flex-col z-10">
 							<div class="border border-gray-600 rounded-xl p-1 flex flex-col w-[90px]">
-								<p class="font-light self-center mb-0.5">Octave</p>
+								<p class="font-light text-sm self-center mb-0.5">Octave</p>
 								<webaudio-slider
 									id="master_octave"
 									class="control mainControl4 self-center"
@@ -1579,14 +1648,14 @@
 									max="4"
 									value="2"
 									direction="vert"
-									height="85"
+									height="50"
 									conv="['-2','-1','0','+1','+2'][x]"
 								></webaudio-slider>
 								<webaudio-param
 									id="master_octave_readout"
 									link="master_octave"
 									class="self-center border border-gray-500 mt-1"
-									fontSize="14"
+									fontSize="10"
 									width="60"
 								></webaudio-param>
 							</div>
@@ -1596,6 +1665,7 @@
 						<webaudio-keyboard
 							id="keyboard"
 							keys="61"
+							height="85"
 							class="self-center"
 						></webaudio-keyboard>
 					</div>

--- a/index.html
+++ b/index.html
@@ -26,1703 +26,1758 @@
 	<title>MS24</title>
 </head>
 <body class="min-h-screen antialiased bg-custom-black font-inconsolata font-light text-white">
-	<main id="body_container" class="flex justify-center">
-		<div id="consent_container" class="bg-custom-black">
-			<div class="flex flex-col select-none mx-10">
-				<hr class="w-full mt-5 mb-4"/>
-				<a
-					href="https://github.com/IADT-projects/y4-project-Mangoshi"
-					target="_blank"
-					class="self-center hover:scale-110 transition-all duration-500 ease-in-out"
-				>
-					<img src="img/logo.png" alt="logo" class="pointer-events-none w-full h-full"/>
-				</a>
-				<hr class="w-full mt-3 mb-5"/>
-				<p class="text-lg text-center">
-					Welcome to MangoSynth24!
-					<br/>
-					This site uses the Web Audio API to generate sounds.
-					<br/>
-					To use this site, you must first allow the browser to use the Web Audio API.
-				</p>
-				<button
-					id="context_consent_button"
-					class="bg-green-600 text-white rounded-lg px-4
+<main id="body_container" class="flex justify-center">
+	<div id="consent_container" class="bg-custom-black">
+		<div class="flex flex-col select-none mx-10">
+			<hr class="w-full mt-5 mb-4"/>
+			<a
+				href="https://github.com/IADT-projects/y4-project-Mangoshi"
+				target="_blank"
+				class="self-center hover:scale-110 transition-all duration-500 ease-in-out"
+			>
+				<img src="img/logo.png" alt="logo" class="pointer-events-none w-full h-full"/>
+			</a>
+			<hr class="w-full mt-3 mb-5"/>
+			<p class="text-lg text-center">
+				Welcome to MangoSynth24!
+				<br/>
+				This site uses the Web Audio API to generate sounds.
+				<br/>
+				To use this site, you must first allow the browser to use the Web Audio API.
+			</p>
+			<button
+				id="context_consent_button"
+				class="bg-green-600 text-white rounded-lg px-4
 					py-2 mt-4 hover:bg-green-500 transition-all
 					duration-300 ease-in-out self-center text-xl">
-					Allow 😄
-				</button>
-				<hr class="w-full mt-5 mb-1"/>
-				<p class="text-2xl self-center">Attention!</p>
-				<hr class="w-full mt-1 mb-5"/>
-				<div>
-					<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
-						<i>Recommended browsers: Chrome, Brave, Opera, Vivaldi, Edge</i>
-						<br/>
-						<i>Other browsers don't use the V8 engine, which can lead to lower performance.</i>
-					</div>
+				Allow 😄
+			</button>
+			<hr class="w-full mt-5 mb-1"/>
+			<p class="text-2xl self-center">Attention!</p>
+			<hr class="w-full mt-1 mb-5"/>
+			<div>
+				<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
+					<i>Recommended browsers: Chrome, Brave, Opera, Vivaldi, Edge</i>
+					<br/>
+					<i>Other browsers don't use the V8 engine, which can lead to lower performance.</i>
 				</div>
-				<hr class="w-full mt-5 mb-1"/>
-				<p class="text-2xl self-center">Controls</p>
-				<hr class="w-full mt-1 mb-5"/>
-				<div>
-					<p class="text-lg underline">Knobs</p>
-					<ul class="list-disc text-lg mb-2">
-						<li class="ml-5">Click and drag on the knobs to adjust the values.</li>
-						<li class="ml-5">You can also scroll the mousewheel while hovering over a knob.</li>
-						<li class="ml-5">Hold SHIFT on the keyboard while adjusting knobs to fine-tune.</li>
-						<li class="ml-5">Hold CTRL on the keyboard and click a knob to return it to default.
-						<li class="ml-5">Right-click a knob to bring up the MIDI-learn context menu.</li>
-					</ul>
+			</div>
+			<hr class="w-full mt-5 mb-1"/>
+			<p class="text-2xl self-center">Controls</p>
+			<hr class="w-full mt-1 mb-5"/>
+			<div>
+				<p class="text-lg underline">Knobs</p>
+				<ul class="list-disc text-lg mb-2">
+					<li class="ml-5">Click and drag on the knobs to adjust the values.</li>
+					<li class="ml-5">You can also scroll the mousewheel while hovering over a knob.</li>
+					<li class="ml-5">Hold SHIFT on the keyboard while adjusting knobs to fine-tune.</li>
+					<li class="ml-5">Hold CTRL on the keyboard and click a knob to return it to default.
+					<li class="ml-5">Right-click a knob to bring up the MIDI-learn context menu.</li>
+				</ul>
+			</div>
+			<div>
+				<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
+					<i>Note: Changing octave/detune while holding a key will cause it to stick down! This is a bug.</i>
+					<br/>
+					<i>To fix, either switch back to the octave/detune value you were on and press the same key...</i>
+					<br/>
+					<i>Or reload the page. I apologize for this, it's a tricky bug to squash 🐛</i>
 				</div>
-				<div>
-					<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
-						<i>Note: Changing octave/detune while holding a key will cause it to stick down! This is a bug.</i>
-						<br/>
-						<i>To fix, either switch back to the octave/detune value you were on and press the same key...</i>
-						<br/>
-						<i>Or reload the page. I apologize for this, it's a tricky bug to squash 🐛</i>
-					</div>
-				</div>
-				<div>
-					<p class="text-lg underline">Keyboard</p>
-					<ul class="list-disc text-lg mb-2">
-						<li class="ml-5">Click the keys on the keyboard to play a sound.</li>
-						<li class="ml-5">You can also use your computer keyboard if your cursor is hovering over it.</li>
-						<li class="ml-5">ZXC-row = white keys, first octave</li>
-						<li class="ml-5">ASD-row = black keys, first octave</li>
-						<li class="ml-5">QWE-row = white keys, second octave</li>
-						<li class="ml-5">Num-row = black keys, second octave</li>
-					</ul>
-				</div>
-				<div>
-					<p class="text-lg underline">Switches</p>
-					<ul class="list-disc text-lg mb-2">
-						<li class="ml-5">Click on the green buttons to turn parts of the synth on and off.</li>
-					</ul>
-				</div>
-				<div>
-					<p class="text-lg underline">Selectors</p>
-					<ul class="list-disc text-lg mb-2">
-						<li class="ml-5">Click on the select boxes in LFO & FX to change modulation target & effect type</li>
-					</ul>
-				</div>
-				<div>
-					<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
-						<i>Note: LFO select is currently broken, but FX select works!</i>
-					</div>
+			</div>
+			<div>
+				<p class="text-lg underline">Keyboard</p>
+				<ul class="list-disc text-lg mb-2">
+					<li class="ml-5">Click the keys on the keyboard to play a sound.</li>
+					<li class="ml-5">You can also use your computer keyboard if your cursor is hovering over it.</li>
+					<li class="ml-5">ZXC-row = white keys, first octave</li>
+					<li class="ml-5">ASD-row = black keys, first octave</li>
+					<li class="ml-5">QWE-row = white keys, second octave</li>
+					<li class="ml-5">Num-row = black keys, second octave</li>
+				</ul>
+			</div>
+			<div>
+				<p class="text-lg underline">Switches</p>
+				<ul class="list-disc text-lg mb-2">
+					<li class="ml-5">Click on the green buttons to turn parts of the synth on and off.</li>
+				</ul>
+			</div>
+			<div>
+				<p class="text-lg underline">Selectors</p>
+				<ul class="list-disc text-lg mb-2">
+					<li class="ml-5">Click on the select boxes in LFO & FX to change modulation target & effect type</li>
+				</ul>
+			</div>
+			<div>
+				<div class="info_block border border-gray-400 bg-black w-[800px] p-2 mb-2">
+					<i>Note: LFO select is currently broken, but FX select works!</i>
 				</div>
 			</div>
 		</div>
-		<div class="flex-col hidden w-min select-none bg-custom-black border border-orange-300 rounded-lg p-2" id="synth_container">
-			<div id="p5_canvas" class="self-center absolute"></div>
-			<!--********************-->
-			<!-- 	  TOP ROW 	    -->
-			<!--********************-->
-			<div id="top_row_container" class="flex justify-between w-full px-1 py-1 z-10 border border-gray-600 border-b-0 rounded-lg">
-				<div class="w-[250px] flex">
-					<div class="flex self-center">
-						<button
-							id="settings_button"
-							class="
+	</div>
+	<div class="flex-col hidden w-min select-none bg-custom-black border border-orange-300 rounded-lg p-2" id="synth_container">
+		<div id="p5_canvas" class="self-center absolute"></div>
+		<!--********************-->
+		<!-- 	  TOP ROW 	    -->
+		<!--********************-->
+		<div id="top_row_container" class="flex justify-between w-full px-1 py-1 z-10 border border-gray-600 border-b-0 rounded-lg">
+			<div class="w-[250px] flex">
+				<div class="flex self-center">
+					<button
+						id="settings_button"
+						class="
 							dropdownButton
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
-							SETTINGS
-						</button>
-						<div
-							id="settings_dropdown"
-							class="
+						SETTINGS
+					</button>
+					<div
+						id="settings_dropdown"
+						class="
 							dropdown_content
 							hidden absolute mt-8 w-[120px] z-10
 							bg-custom-black border border-white rounded-lg">
-							<a
-								id="settings_home_button"
-								class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-bl-none rounded-br-none"
-							>Back Home</a>
-							<a
-								id="settings_theme_button"
-								class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-tl-none rounded-tr-none"
-							>Toggle Theme</a>
-						</div>
+						<a
+							id="settings_home_button"
+							class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-bl-none rounded-br-none"
+						>Back Home</a>
+						<a
+							id="settings_theme_button"
+							class="cursor-pointer flex p-2 hover:bg-stone-600 rounded-lg rounded-tl-none rounded-tr-none"
+						>Toggle Theme</a>
 					</div>
 				</div>
-				<div class="w-[250px] flex justify-between">
-					<div class="flex flex-col justify-center">
-						<button
-							id="presets_button"
-							class="
+			</div>
+			<div class="w-[250px] flex justify-between">
+				<div class="flex flex-col justify-center">
+					<button
+						id="presets_button"
+						class="
 							w-[75px]
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
-							PRESETS
-						</button>
-					</div>
-					<div class="flex flex-col justify-center">
-						<a href="https://github.com/IADT-projects/y4-project-Mangoshi" target="_blank">
-							<img
-								src="img/logo.png"
-								alt="logo"
-								class="hover:scale-125 transition-all duration-500 ease-in-out"
-								height="75"
-								width="75"
-							/>
-						</a>
-					</div>
-					<div class="flex flex-col justify-center">
-						<button
-							id="random_preset_button"
-							class="w-[75px]
+						PRESETS
+					</button>
+				</div>
+				<div class="flex flex-col justify-center">
+					<a href="https://github.com/IADT-projects/y4-project-Mangoshi" target="_blank">
+						<img
+							src="img/logo.png"
+							alt="logo"
+							class="hover:scale-125 transition-all duration-500 ease-in-out"
+							height="75"
+							width="75"
+						/>
+					</a>
+				</div>
+				<div class="flex flex-col justify-center">
+					<button
+						id="random_preset_button"
+						class="w-[75px]
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
-							RANDOM
-						</button>
-					</div>
-				</div>
-				<div class="w-[250px] flex justify-end">
-					<!--
-					<div class="flex flex-col p-1 border border-gray-600 rounded-lg">
-						<div class="border border-gray-600 border-b-0 rounded-lg rounded-br-none rounded-bl-none p-1 flex mr-1 h-min">
-							<p id="master_gain_label_h" class="text-sm self-center w-[30px]">Vol</p>
-							<webaudio-knob
-								id="master_gain_h"
-								class="control masterControl ml-1"
-								colors="#FFFFFF;#2C292D;#D9D9D9"
-								diameter="30"
-								min="0"
-								max="2"
-								value="1"
-								step=".01"
-							></webaudio-knob>
-							<webaudio-param
-								id="master_gain_readout_h"
-								link="master_gain_h"
-								fontSize="10"
-								class="border border-gray-600 self-center ml-2"
-							></webaudio-param>
-						</div>
-						<div class="border border-gray-600 border-t-0 rounded-lg rounded-tr-none rounded-tl-none p-1 flex mr-1 h-min">
-							<p id="master_bpm_label_h" class="text-sm self-center w-[30px]">BPM</p>
-							<webaudio-knob
-								id="master_bpm_h"
-								class="control masterControl ml-1"
-								colors="#FFFFFF;#2C292D;#D9D9D9"
-								diameter="30"
-								min="1"
-								max="600"
-								value="120"
-								step="1"
-							></webaudio-knob>
-							<webaudio-param
-								id="master_bpm_readout_h"
-								link="master_bpm_h"
-								fontSize="10"
-								class="border border-gray-600 self-center ml-2"
-							></webaudio-param>
-						</div>
-					</div>
-					-->
-					<div class="flex p-1 border border-gray-600 rounded-lg">
-						<div class="border border-gray-600 rounded-lg p-1 flex flex-col mr-1 w-[50px]">
-							<p id="master_bpm_label" class="text-center text-sm">BPM</p>
-							<webaudio-knob
-								id="master_bpm"
-								class="control masterControl self-center"
-								colors="#FFFFFF;#2C292D;#D9D9D9"
-								diameter="30"
-								min="1"
-								max="600"
-								value="120"
-								step="1"
-							></webaudio-knob>
-							<webaudio-param
-								id="master_bpm_readout"
-								link="master_bpm"
-								fontSize="10"
-								class="self-center border border-gray-600 mt-1"
-							></webaudio-param>
-						</div>
-						<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[50px]">
-							<p id="master_gain_label" class="text-center text-sm">Gain</p>
-							<webaudio-knob
-								id="master_gain"
-								class="control masterControl self-center"
-								colors="#FFFFFF;#2C292D;#D9D9D9"
-								diameter="30"
-								min="0"
-								max="2"
-								value="1"
-								step="0.01"
-							></webaudio-knob>
-							<webaudio-param
-								id="master_gain_readout"
-								link="master_gain"
-								fontSize="10"
-								class="self-center border border-gray-600 mt-1"
-							></webaudio-param>
-						</div>
-					</div>
-
+						RANDOM
+					</button>
 				</div>
 			</div>
-			<div id="synth_body" class="flex flex-col">
-				<!--********************-->
-				<!--	  ROW ONE 	    -->
-				<!--********************-->
-				<div class="flex z-0">
-					<!--********************-->
-					<!--	OSCILLATOR A	-->
-					<!--********************-->
-					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="flex justify-between mb-1">
-								<div class="flex flex-col">
-									<div class="flex p-1">
-										<webaudio-switch
-											id="osc_a_switch"
-											class="control toggleControl self-center pr-1"
-											colors="#A9DC76;#2C292D;#D9D9D9"
-											diameter="30"
-											value="1"
-										></webaudio-switch>
-										<p class="font-inika self-center">OSC A</p>
-									</div>
-									<div class="flex p-1">
-										<webaudio-switch
-											id="arp_a_switch"
-											class="control"
-											colors="#AB9DF2;#2C292D;#D9D9D9"
-											diameter="30"
-											value="0"
-										></webaudio-switch>
-										<p id="arp_a_label" class="font-inika ml-1">ARP</p>
-									</div>
-								</div>
-								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Voices</p>
-										<webaudio-knob
-											id="osc_a_voices"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="24"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_a_voices_readout"
-											link="osc_a_voices"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Spread</p>
-										<webaudio-knob
-											id="osc_a_spread"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="100"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_a_spread_readout"
-											link="osc_a_spread"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">FM</p>
-										<webaudio-knob
-											id="osc_a_fm"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="50"
-											value="0"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_a_fm_readout"
-											link="osc_a_fm"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Depth</p>
-										<webaudio-knob
-											id="osc_a_fm_depth"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="50"
-											value="0"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_a_fm_depth_readout"
-											link="osc_a_fm_depth"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Shape</p>
-										<webaudio-knob
-											id="osc_a_fm_shape"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="3"
-											value="0"
-											step="1"
-											conv="['sin','tri','saw','sqr'][x]"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_a_fm_shape_readout"
-											link="osc_a_fm_shape"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-								</div>
-							</div>
-							<div class="flex">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Octave</p>
-									<webaudio-knob
-										id="osc_a_octave"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-3"
-										max="3"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_octave_readout"
-										link="osc_a_octave"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Detune</p>
-									<webaudio-knob
-										id="osc_a_semi"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-12"
-										max="12"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_semi_readout"
-										link="osc_a_semi"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Volume</p>
-									<webaudio-knob
-										id="osc_a_volume"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-10"
-										max="10"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_volume_readout"
-										link="osc_a_volume"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Shape</p>
-									<webaudio-slider
-										id="osc_a_shape"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										height="50"
-										min="0"
-										max="3"
-										direction="vert"
-										conv="['sine','triangle','sawtooth','square'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="osc_a_shape_readout"
-										link="osc_a_shape"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-							</div>
-						</div>
-						<!--right-->
-						<div class="flex flex-col">
-							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">ATK</p>
-									<webaudio-knob
-										id="osc_a_attack"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.005"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_attack_readout"
-										link="osc_a_attack"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">DEC</p>
-									<webaudio-knob
-										id="osc_a_decay"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_decay_readout"
-										link="osc_a_decay"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">SUS</p>
-									<webaudio-knob
-										id="osc_a_sustain"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="1"
-										value="0.3"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_sustain_readout"
-										link="osc_a_sustain"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
-									<p class="font-light text-sm self-center mb-0.5">REL</p>
-									<webaudio-knob
-										id="osc_a_release"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="5"
-										value="1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_a_release_readout"
-										link="osc_a_release"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-							</div>
-							<div id="osc_a_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_a_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
+			<div class="w-[250px] flex justify-end">
+				<!--
+				<div class="flex flex-col p-1 border border-gray-600 rounded-lg">
+					<div class="border border-gray-600 border-b-0 rounded-lg rounded-br-none rounded-bl-none p-1 flex mr-1 h-min">
+						<p id="master_gain_label_h" class="text-sm self-center w-[30px]">Vol</p>
+						<webaudio-knob
+							id="master_gain_h"
+							class="control masterControl ml-1"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="30"
+							min="0"
+							max="2"
+							value="1"
+							step=".01"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_gain_readout_h"
+							link="master_gain_h"
+							fontSize="10"
+							class="border border-gray-600 self-center ml-2"
+						></webaudio-param>
 					</div>
-					<!--********************-->
-					<!--	  MIDDLE		-->
-					<!--********************-->
-					<div class="self-center w-[61px] mx-1 z-10"></div>
-					<!--********************-->
-					<!--	OSCILLATOR B	-->
-					<!--********************-->
-					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="flex justify-between mb-1">
-								<div class="flex flex-col">
-									<div class="flex p-1">
-										<webaudio-switch
-											id="osc_b_switch"
-											class="control toggleControl self-center pr-1"
-											colors="#A9DC76;#2C292D;#D9D9D9"
-											diameter="30"
-											value="0"
-										></webaudio-switch>
-										<p class="font-inika self-center">OSC B</p>
-									</div>
-									<div class="flex p-1">
-										<webaudio-switch
-											id="arp_b_switch"
-											class="control"
-											colors="#AB9DF2;#2C292D;#D9D9D9"
-											diameter="30"
-											value="0"
-										></webaudio-switch>
-										<p id="arp_b_label" class="font-inika ml-1">ARP</p>
-									</div>
-								</div>
-								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Voices</p>
-										<webaudio-knob
-											id="osc_b_voices"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="24"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_b_voices_readout"
-											link="osc_b_voices"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Spread</p>
-										<webaudio-knob
-											id="osc_b_spread"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="100"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_b_spread_readout"
-											link="osc_b_spread"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">FM</p>
-										<webaudio-knob
-											id="osc_b_fm"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="50"
-											value="0"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_b_fm_readout"
-											link="osc_b_fm"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Depth</p>
-										<webaudio-knob
-											id="osc_b_fm_depth"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="50"
-											value="0"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_b_fm_depth_readout"
-											link="osc_b_fm_depth"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Shape</p>
-										<webaudio-knob
-											id="osc_b_fm_shape"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="3"
-											value="0"
-											step="1"
-											conv="['sin','tri','saw','sqr'][x]"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_b_fm_shape_readout"
-											link="osc_b_fm_shape"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-								</div>
-							</div>
-							<div class="flex">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Octave</p>
-									<webaudio-knob
-										id="osc_b_octave"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-3"
-										max="3"
-										value="1"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_octave_readout"
-										link="osc_b_octave"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Detune</p>
-									<webaudio-knob
-										id="osc_b_semi"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-12"
-										max="12"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_semi_readout"
-										link="osc_b_semi"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Volume</p>
-									<webaudio-knob
-										id="osc_b_volume"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-10"
-										max="10"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_volume_readout"
-										link="osc_b_volume"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Shape</p>
-									<webaudio-slider
-										id="osc_b_shape"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										height="50"
-										min="0"
-										max="3"
-										value="1"
-										direction="vert"
-										conv="['sine','triangle','sawtooth','square'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="osc_b_shape_readout"
-										link="osc_b_shape"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-							</div>
-						</div>
-						<!--right-->
-						<div class="flex flex-col">
-							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">ATK</p>
-									<webaudio-knob
-										id="osc_b_attack"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.005"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_attack_readout"
-										link="osc_b_attack"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">DEC</p>
-									<webaudio-knob
-										id="osc_b_decay"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_decay_readout"
-										link="osc_b_decay"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">SUS</p>
-									<webaudio-knob
-										id="osc_b_sustain"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="1"
-										value="0.3"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_sustain_readout"
-										link="osc_b_sustain"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
-									<p class="font-light text-sm self-center mb-0.5">REL</p>
-									<webaudio-knob
-										id="osc_b_release"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="5"
-										value="1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_b_release_readout"
-										link="osc_b_release"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-							</div>
-							<div id="osc_b_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_b_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
+					<div class="border border-gray-600 border-t-0 rounded-lg rounded-tr-none rounded-tl-none p-1 flex mr-1 h-min">
+						<p id="master_bpm_label_h" class="text-sm self-center w-[30px]">BPM</p>
+						<webaudio-knob
+							id="master_bpm_h"
+							class="control masterControl ml-1"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="30"
+							min="1"
+							max="600"
+							value="120"
+							step="1"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_bpm_readout_h"
+							link="master_bpm_h"
+							fontSize="10"
+							class="border border-gray-600 self-center ml-2"
+						></webaudio-param>
 					</div>
 				</div>
-				<!--********************-->
-				<!--	  ROW TWO 	    -->
-				<!--********************-->
-				<div class="flex z-10">
-					<!--********************-->
-					<!--  SUB OSCILLATOR	-->
-					<!--********************-->
-					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="flex justify-between mb-1">
-								<div class="flex flex-col">
-									<div class="flex p-1">
-										<webaudio-switch
-											id="osc_c_switch"
-											class="control toggleControl self-center pr-1"
-											colors="#A9DC76;#2C292D;#D9D9D9"
-											diameter="30"
-											value="0"
-										></webaudio-switch>
-										<p class="font-inika self-center">SUB OSC</p>
-									</div>
-									<div class="flex p-1">
-										<webaudio-switch
-											id="arp_c_switch"
-											class="control"
-											colors="#AB9DF2;#2C292D;#D9D9D9"
-											diameter="30"
-											value="0"
-										></webaudio-switch>
-										<p id="arp_c_label" class="font-inika ml-1">ARP</p>
-									</div>
-								</div>
-								<div class="self-center border border-gray-600 flex rounded-lg p-1">
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Voices</p>
-										<webaudio-knob
-											id="osc_c_voices"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="24"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_c_voices_readout"
-											link="osc_c_voices"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Spread</p>
-										<webaudio-knob
-											id="osc_c_spread"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="1"
-											max="100"
-											value="1"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_c_spread_readout"
-											link="osc_c_spread"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">AM</p>
-										<webaudio-knob
-											id="osc_c_am"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="50"
-											value="0"
-											step="1"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_c_am_readout"
-											link="osc_c_am"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-									<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
-										<p class="font-light text-sm self-center mb-0.5">Shape</p>
-										<webaudio-knob
-											id="osc_c_am_shape"
-											class="control subControl self-center"
-											colors="#FFFFFF;#2C292D;#D9D9D9"
-											diameter="30"
-											min="0"
-											max="3"
-											value="0"
-											step="1"
-											conv="['sin','tri','saw','sqr'][x]"
-										></webaudio-knob>
-										<webaudio-param
-											id="osc_c_am_shape_readout"
-											link="osc_c_am_shape"
-											class="self-center border border-gray-600 mt-1"
-											fontSize="10"
-											width="30"
-										></webaudio-param>
-									</div>
-								</div>
-							</div>
-							<div class="flex">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Octave</p>
-									<webaudio-knob
-										id="osc_c_octave"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="3"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_octave_readout"
-										link="osc_c_octave"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Detune</p>
-									<webaudio-knob
-										id="osc_c_semi"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-12"
-										max="12"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_semi_readout"
-										link="osc_c_semi"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Volume</p>
-									<webaudio-knob
-										id="osc_c_volume"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										diameter="50"
-										min="-10"
-										max="10"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_volume_readout"
-										link="osc_c_volume"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Shape</p>
-									<webaudio-slider
-										id="osc_c_shape"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										height="50"
-										min="0"
-										max="3"
-										value="2"
-										direction="vert"
-										conv="['sine','triangle','sawtooth','square'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="osc_c_shape_readout"
-										link="osc_c_shape"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-							</div>
-						</div>
-						<!--right-->
-						<div class="flex flex-col">
-							<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">ATK</p>
-									<webaudio-knob
-										id="osc_c_attack"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.005"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_attack_readout"
-										link="osc_c_attack"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">DEC</p>
-									<webaudio-knob
-										id="osc_c_decay"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="2"
-										value="0.1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_decay_readout"
-										link="osc_c_decay"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
-									<p class="font-light text-sm self-center mb-0.5">SUS</p>
-									<webaudio-knob
-										id="osc_c_sustain"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="1"
-										value="0.3"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_sustain_readout"
-										link="osc_c_sustain"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
-									<p class="font-light text-sm self-center mb-0.5">REL</p>
-									<webaudio-knob
-										id="osc_c_release"
-										class="control adsrControl self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										diameter="30"
-										min="0"
-										max="5"
-										value="1"
-										step="0.001"
-									></webaudio-knob>
-									<webaudio-param
-										id="osc_c_release_readout"
-										link="osc_c_release"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="30"
-									></webaudio-param>
-								</div>
-							</div>
-							<div id="osc_c_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="osc_c_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
+				-->
+				<div class="flex p-1 border border-gray-600 rounded-lg">
+					<div class="border border-gray-600 rounded-lg p-1 flex flex-col mr-1 w-[50px]">
+						<p id="master_bpm_label" class="text-center text-sm">BPM</p>
+						<webaudio-knob
+							id="master_bpm"
+							class="control masterControl self-center"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="30"
+							min="1"
+							max="600"
+							value="120"
+							step="1"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_bpm_readout"
+							link="master_bpm"
+							fontSize="10"
+							class="self-center border border-gray-600 mt-1"
+							colors="#FFF;#000"
+						></webaudio-param>
 					</div>
-					<!--********************-->
-					<!--   FM VISUALISER 	-->
-					<!--********************-->
-					<div class="self-center border border-gray-600 flex rounded-lg p-1 mx-1 z-10">
-						<canvas class="self-center" id="fm_canvas" width="51" height="50"></canvas>
+					<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[50px]">
+						<p id="master_gain_label" class="text-center text-sm">Gain</p>
+						<webaudio-knob
+							id="master_gain"
+							class="control masterControl self-center"
+							colors="#FFFFFF;#2C292D;#D9D9D9"
+							diameter="30"
+							min="0"
+							max="2"
+							value="1"
+							step="0.01"
+						></webaudio-knob>
+						<webaudio-param
+							id="master_gain_readout"
+							link="master_gain"
+							fontSize="10"
+							class="self-center border border-gray-600 mt-1"
+							colors="#FFF;#000"
+						></webaudio-param>
 					</div>
-					<!--********************-->
-					<!--    MULTI FILTER    -->
-					<!--********************-->
-					<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="h-[98px] mb-1">
+				</div>
+
+			</div>
+		</div>
+		<div id="synth_body" class="flex flex-col">
+			<!--********************-->
+			<!--	  ROW ONE 	    -->
+			<!--********************-->
+			<div class="flex z-0">
+				<!--********************-->
+				<!--	OSCILLATOR A	-->
+				<!--********************-->
+				<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="flex justify-between mb-1">
+							<div class="flex flex-col">
 								<div class="flex p-1">
 									<webaudio-switch
-										id="filter_switch"
+										id="osc_a_switch"
 										class="control toggleControl self-center pr-1"
 										colors="#A9DC76;#2C292D;#D9D9D9"
 										diameter="30"
 										value="1"
 									></webaudio-switch>
-									<p class="font-inika self-center">FILTER</p>
+									<p class="font-inika self-center">OSC A</p>
+								</div>
+								<div class="flex p-1">
+									<webaudio-switch
+										id="arp_a_switch"
+										class="control"
+										colors="#AB9DF2;#2C292D;#D9D9D9"
+										diameter="30"
+										value="0"
+									></webaudio-switch>
+									<p id="arp_a_label" class="font-inika ml-1">ARP</p>
 								</div>
 							</div>
-
-							<div class="flex">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Cutoff</p>
+							<div class="self-center border border-gray-600 flex rounded-lg p-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Voices</p>
 									<webaudio-knob
-										id="filter_cutoff"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="5"
-										max="10000"
-										value="5000"
-										step="5"
-									></webaudio-knob>
-									<webaudio-param
-										id="filter_cutoff_readout"
-										link="filter_cutoff"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div id="filter_resonance_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
-									<webaudio-knob
-										id="filter_resonance"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
+										id="osc_a_voices"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
 										min="1"
-										max="10"
-										value="0"
-										step="0.1"
+										max="24"
+										value="1"
+										step="1"
 									></webaudio-knob>
 									<webaudio-param
-										id="filter_resonance_readout"
-										link="filter_resonance"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
+										id="osc_a_voices_readout"
+										link="osc_a_voices"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
 									></webaudio-param>
 								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Rolloff</p>
-									<webaudio-slider
-										id="filter_rolloff"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										height="50"
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Spread</p>
+									<webaudio-knob
+										id="osc_a_spread"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="1"
+										max="100"
+										value="1"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_a_spread_readout"
+										link="osc_a_spread"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">FM</p>
+									<webaudio-knob
+										id="osc_a_fm"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="50"
+										value="0"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_a_fm_readout"
+										link="osc_a_fm"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Depth</p>
+									<webaudio-knob
+										id="osc_a_fm_depth"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="50"
+										value="0"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_a_fm_depth_readout"
+										link="osc_a_fm_depth"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Shape</p>
+									<webaudio-knob
+										id="osc_a_fm_shape"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
 										min="0"
 										max="3"
-										step="1"
-										direction="vert"
-										conv="['-12','-24','-48','-96'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="filter_rolloff_readout"
-										link="filter_rolloff"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Type</p>
-									<webaudio-slider
-										id="filter_type"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										height="50"
-										min="0"
-										max="6"
-										step="1"
-										value="0"
-										direction="vert"
-										conv="['LPF','HPF','BPF','APF','Notch','LSF','HSF'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="filter_type_readout"
-										link="filter_type"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-							</div>
-						</div>
-						<!--right-->
-						<div class="flex flex-col justify-center">
-							<div class="self-center border border-gray-600 flex justify-around rounded-lg p-1 mb-1 w-[222px] h-[98px]">
-								<div class="p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center w-max">Send A</p>
-									<webaudio-switch
-										id="osc_a_filter_switch"
-										class="control toggleControl self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="30"
-										value="1"
-									></webaudio-switch>
-								</div>
-								<div class="p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center w-max">Send B</p>
-									<webaudio-switch
-										id="osc_b_filter_switch"
-										class="control toggleControl self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="30"
-										value="1"
-									></webaudio-switch>
-								</div>
-								<div class="p-0.5 w-min flex flex-col justify-center">
-									<p class="font-light text-sm self-center w-max">Send C</p>
-									<webaudio-switch
-										id="osc_c_filter_switch"
-										class="control toggleControl self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="30"
-										value="1"
-									></webaudio-switch>
-								</div>
-							</div>
-							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="filter_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!--********************-->
-				<!--	 ROW THREE 	    -->
-				<!--********************-->
-				<div class="flex z-10">
-					<!--********************-->
-					<!--   LOW FREQ OSC 	-->
-					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="flex p-1">
-								<webaudio-switch
-									id="lfo_switch"
-									class="control toggleControl self-center pr-1"
-									colors="#A9DC76;#2C292D;#D9D9D9"
-									diameter="30"
-									value="0"
-								></webaudio-switch>
-								<label class="font-inika self-center" for="lfo_selector">
-									LFO
-									&nbsp;
-									<select
-										id="lfo_selector"
-										class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
-										autocomplete="off"
-									>
-										<option value="FilterFrequency" selected="selected">Filter Frequency</option>
-										<option value="OscAVol">OSC A Volume</option>
-										<option value="OscBVol">OSC B Volume</option>
-										<option value="OscCVol">OSC C Volume</option>
-									</select>
-								</label>
-							</div>
-							<div class="flex">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Grid</p>
-									<webaudio-knob
-										id="lfo_grid"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="9"
-										value="5"
-										step="1"
-										conv="['8/1','4/1','2/1','1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
-									></webaudio-knob>
-									<webaudio-param
-										id="lfo_grid_readout"
-										link="lfo_grid"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Min</p>
-									<webaudio-knob
-										id="lfo_min"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="10000"
 										value="0"
 										step="1"
+										conv="['sin','tri','saw','sqr'][x]"
 									></webaudio-knob>
 									<webaudio-param
-										id="lfo_min_readout"
-										link="lfo_min"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p class="font-light self-center mb-0.5">Max</p>
-									<webaudio-knob
-										id="lfo_max"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="10000"
-										value="1000"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="lfo_max_readout"
-										link="lfo_max"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light self-center mb-0.5">Shape</p>
-									<webaudio-slider
-										id="lfo_shape"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										height="50"
-										min="0"
-										max="3"
-										step="1"
-										value="0"
-										direction="vert"
-										conv="['sine','triangle','sawtooth','square'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="lfo_shape_readout"
-										link="lfo_shape"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
+										id="osc_a_fm_shape_readout"
+										link="osc_a_fm_shape"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
 									></webaudio-param>
 								</div>
 							</div>
 						</div>
-						<!--right-->
-						<div>
-							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
-							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="lfo_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
-					</div>
-					<!--************-->
-					<!--   MIDDLE 	-->
-					<!--************-->
-					<div class="self-center w-[61px] mx-1 z-10"></div>
-					<!--********************-->
-					<!--     MULTI FX       -->
-					<!--********************-->
-					<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
-						<!--left-->
-						<div class="flex flex-col justify-between mr-1">
-							<div class="flex p-1">
-								<webaudio-switch
-									id="fx_switch"
-									class="control toggleControl self-center pr-1"
-									colors="#A9DC76;#2C292D;#D9D9D9"
-									diameter="30"
-									value="1"
-								></webaudio-switch>
-								<label class="font-inika self-center" for="fx_selector">
-									FX
-									&nbsp;
-									<select
-										id="fx_selector"
-										class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
-										autocomplete="off"
-									>
-										<option value="Distortion" selected="selected">Distortion</option>
-										<option value="Chebyshev">Chebyshev Distortion</option>
-										<option value="Phaser">Phaser</option>
-										<option value="Tremolo">Tremolo</option>
-										<option value="Vibrato">Vibrato</option>
-										<option value="Delay">Delay</option>
-										<option value="Reverb">Reverb</option>
-										<option value="PitchShift">Pitch Shift</option>
-										<option value="FreqShift">Freq Shift</option>
-									</select>
-								</label>
-							</div>
-							<div class="flex w-[372px]">
-								<div id="fx_param1_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p id="fx_param1_label" class="font-light self-center mb-0.5">Intensity</p>
-									<webaudio-knob
-										id="fx_param1"
-										class="control mainControl1 self-center"
-										colors="#FF6188;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="20"
-										value="0"
-										step="0.1"
-									></webaudio-knob>
-									<webaudio-param
-										id="fx_param1_readout"
-										link="fx_param1"
-										fontSize="14"
-										width="60"
-										class="self-center border border-pink-800 mt-1"
-									></webaudio-param>
-								</div>
-								<div id="fx_param2_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p id="fx_param2_label" class="font-light self-center mb-0.5">Oversample</p>
-									<webaudio-knob
-										id="fx_param2"
-										class="control mainControl2 self-center"
-										colors="#A9DC76;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="2"
-										value="0"
-										step="1"
-									></webaudio-knob>
-									<webaudio-param
-										id="fx_param2_readout"
-										link="fx_param2"
-										fontSize="14"
-										width="60"
-										class="self-center border border-green-700 mt-1"
-									></webaudio-param>
-								</div>
-								<div id="fx_param3_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-									<p id="fx_param3_label" class="font-light self-center mb-0.5">Mix</p>
-									<webaudio-knob
-										id="fx_param3"
-										class="control mainControl3 self-center"
-										colors="#FFD866;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="1"
-										step=".01"
-										value="0.5"
-									></webaudio-knob>
-									<webaudio-param
-										id="fx_param3_readout"
-										link="fx_param3"
-										class="self-center border border-yellow-600 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-								<div id="fx_param4_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] hidden">
-									<p id="fx_param4_label" class="font-light self-center mb-0.5">Mix</p>
-									<webaudio-knob
-										id="fx_param4"
-										class="control mainControl4 self-center"
-										colors="#78DCE8;#2C292D;#D9D9D9"
-										diameter="50"
-										min="0"
-										max="1"
-										step=".01"
-										value="0.5"
-									></webaudio-knob>
-									<webaudio-param
-										id="fx_param4_readout"
-										link="fx_param4"
-										class="self-center border border-cyan-700 mt-1"
-										fontSize="14"
-										width="60"
-									></webaudio-param>
-								</div>
-							</div>
-						</div>
-						<!--right-->
-						<div class="flex flex-col justify-center">
-							<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
-							<div class="self-center border border-gray-600 flex rounded-lg p-1">
-								<canvas class="self-center" id="fx_canvas" width="212" height="102"></canvas>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!--********************-->
-				<!-- 	  KEYBOARD 	    -->
-				<!--********************-->
-				<div class="flex justify-center p-1 z-10 border border-gray-600 border-t-0 rounded-lg">
-					<div class="w-full flex justify-between z-10">
 						<div class="flex">
-							<div class="flex flex-col mr-1 z-10">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light text-sm self-center mb-0.5">Pattern</p>
-									<webaudio-slider
-										id="arp_pattern"
-										class="control mainControl4 self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										min="0"
-										max="8"
-										value="0"
-										direction="vert"
-										height="50"
-										conv="['up','down','upDown','downUp','alternateUp','alternateDown','random','randomOnce','randomWalk'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="arp_pattern_readout"
-										link="arp_pattern"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="60"
-									></webaudio-param>
-								</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Octave</p>
+								<webaudio-knob
+									id="osc_a_octave"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-3"
+									max="3"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_octave_readout"
+									link="osc_a_octave"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
 							</div>
-							<div class="flex flex-col mr-1 z-10">
-								<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-									<p class="font-light text-sm self-center mb-0.5">Speed</p>
-									<webaudio-slider
-										id="arp_speed"
-										class="control mainControl4 self-center"
-										colors="#AB9DF2;#2C292D;#D9D9D9"
-										min="0"
-										max="6"
-										value="3"
-										direction="vert"
-										height="50"
-										conv="['1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
-									></webaudio-slider>
-									<webaudio-param
-										id="arp_speed_readout"
-										link="arp_speed"
-										class="self-center border border-violet-900 mt-1"
-										fontSize="10"
-										width="60"
-									></webaudio-param>
-								</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Detune</p>
+								<webaudio-knob
+									id="osc_a_semi"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-12"
+									max="12"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_semi_readout"
+									link="osc_a_semi"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
 							</div>
-							<div class="p-1 flex flex-col w-[90px] mr-1"></div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Volume</p>
+								<webaudio-knob
+									id="osc_a_volume"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-10"
+									max="10"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_volume_readout"
+									link="osc_a_volume"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
 							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
-								<p class="font-light text-sm self-center mb-0.5">Octave</p>
+								<p class="font-light self-center mb-0.5">Shape</p>
 								<webaudio-slider
-									id="master_octave"
+									id="osc_a_shape"
 									class="control mainControl4 self-center"
-									colors="#FFFFFF;#2C292D;#D9D9D9"
-									min="0"
-									max="4"
-									value="2"
-									direction="vert"
+									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
-									conv="['-2','-1','0','+1','+2'][x]"
+									min="0"
+									max="3"
+									direction="vert"
+									conv="['sine','triangle','sawtooth','square'][x]"
 								></webaudio-slider>
 								<webaudio-param
-									id="master_octave_readout"
-									link="master_octave"
-									class="self-center border border-gray-600 mt-1"
-									fontSize="10"
+									id="osc_a_shape_readout"
+									link="osc_a_shape"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
 									width="60"
 								></webaudio-param>
 							</div>
 						</div>
 					</div>
-					<div class="border border-gray-600 rounded-lg self-center p-2 mx-1 z-10">
-						<webaudio-keyboard
-							id="keyboard"
-							keys="61"
-							height="85"
-							width="510"
-							class="self-center"
-						></webaudio-keyboard>
+					<!--right-->
+					<div class="flex flex-col">
+						<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">ATK</p>
+								<webaudio-knob
+									id="osc_a_attack"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.005"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_attack_readout"
+									link="osc_a_attack"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">DEC</p>
+								<webaudio-knob
+									id="osc_a_decay"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_decay_readout"
+									link="osc_a_decay"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">SUS</p>
+								<webaudio-knob
+									id="osc_a_sustain"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="1"
+									value="0.3"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_sustain_readout"
+									link="osc_a_sustain"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
+								<p class="font-light text-sm self-center mb-0.5">REL</p>
+								<webaudio-knob
+									id="osc_a_release"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="5"
+									value="1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_a_release_readout"
+									link="osc_a_release"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+						</div>
+						<div id="osc_a_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="osc_a_canvas" width="212" height="102"></canvas>
+						</div>
 					</div>
-					<div class="w-full flex flex-col z-10">
-						<div class="h-full self-end flex items-end">
-							<p id="rec_label" class="mr-1">Record</p>
-							<webaudio-switch
-								id="rec_switch"
-								class="control"
-								colors="#FF6188;#2C292D;#D9D9D9"
-								diameter="30"
-								value="0"
-							></webaudio-switch>
+				</div>
+				<!--********************-->
+				<!--	  MIDDLE		-->
+				<!--********************-->
+				<div class="self-center w-[61px] mx-1 z-10"></div>
+				<!--********************-->
+				<!--	OSCILLATOR B	-->
+				<!--********************-->
+				<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="flex justify-between mb-1">
+							<div class="flex flex-col">
+								<div class="flex p-1">
+									<webaudio-switch
+										id="osc_b_switch"
+										class="control toggleControl self-center pr-1"
+										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="30"
+										value="0"
+									></webaudio-switch>
+									<p class="font-inika self-center">OSC B</p>
+								</div>
+								<div class="flex p-1">
+									<webaudio-switch
+										id="arp_b_switch"
+										class="control"
+										colors="#AB9DF2;#2C292D;#D9D9D9"
+										diameter="30"
+										value="0"
+									></webaudio-switch>
+									<p id="arp_b_label" class="font-inika ml-1">ARP</p>
+								</div>
+							</div>
+							<div class="self-center border border-gray-600 flex rounded-lg p-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Voices</p>
+									<webaudio-knob
+										id="osc_b_voices"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="1"
+										max="24"
+										value="1"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_b_voices_readout"
+										link="osc_b_voices"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Spread</p>
+									<webaudio-knob
+										id="osc_b_spread"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="1"
+										max="100"
+										value="1"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_b_spread_readout"
+										link="osc_b_spread"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">FM</p>
+									<webaudio-knob
+										id="osc_b_fm"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="50"
+										value="0"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_b_fm_readout"
+										link="osc_b_fm"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Depth</p>
+									<webaudio-knob
+										id="osc_b_fm_depth"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="50"
+										value="0"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_b_fm_depth_readout"
+										link="osc_b_fm_depth"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Shape</p>
+									<webaudio-knob
+										id="osc_b_fm_shape"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="3"
+										value="0"
+										step="1"
+										conv="['sin','tri','saw','sqr'][x]"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_b_fm_shape_readout"
+										link="osc_b_fm_shape"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+							</div>
+						</div>
+						<div class="flex">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Octave</p>
+								<webaudio-knob
+									id="osc_b_octave"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-3"
+									max="3"
+									value="1"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_octave_readout"
+									link="osc_b_octave"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Detune</p>
+								<webaudio-knob
+									id="osc_b_semi"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-12"
+									max="12"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_semi_readout"
+									link="osc_b_semi"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Volume</p>
+								<webaudio-knob
+									id="osc_b_volume"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-10"
+									max="10"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_volume_readout"
+									link="osc_b_volume"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light self-center mb-0.5">Shape</p>
+								<webaudio-slider
+									id="osc_b_shape"
+									class="control mainControl4 self-center"
+									colors="#78DCE8;#2C292D;#D9D9D9"
+									height="50"
+									min="0"
+									max="3"
+									value="1"
+									direction="vert"
+									conv="['sine','triangle','sawtooth','square'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="osc_b_shape_readout"
+									link="osc_b_shape"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<!--right-->
+					<div class="flex flex-col">
+						<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">ATK</p>
+								<webaudio-knob
+									id="osc_b_attack"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.005"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_attack_readout"
+									link="osc_b_attack"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">DEC</p>
+								<webaudio-knob
+									id="osc_b_decay"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_decay_readout"
+									link="osc_b_decay"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">SUS</p>
+								<webaudio-knob
+									id="osc_b_sustain"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="1"
+									value="0.3"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_sustain_readout"
+									link="osc_b_sustain"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
+								<p class="font-light text-sm self-center mb-0.5">REL</p>
+								<webaudio-knob
+									id="osc_b_release"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="5"
+									value="1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_b_release_readout"
+									link="osc_b_release"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+						</div>
+						<div id="osc_b_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="osc_b_canvas" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
 			</div>
-			<div id="presets_container" class="hidden w-[1285px] border border-gray-600 border-t-0 rounded-xl rounded-tl-none rounded-tr-none p-1">
-				<!--Presets table: name/type/author/rating/load-->
-				<table id="presets_table" class="table-auto w-full">
-					<thead>
-						<tr class="text-left font-inika">
-							<th class="font-light">Name</th>
-							<th class="font-light">Type</th>
-							<th class="font-light">Author</th>
-							<th class="font-light">Rating</th>
-							<th></th>
-						</tr>
-					</thead>
-					<tbody id="preset_save_body">
-						<tr id="preset_save_row">
-							<td><label for="preset_name_input"></label><input id="preset_name_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset name" value="Init"></td>
-							<td><label for="preset_type_input"></label><input id="preset_type_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset type" value="Default"></td>
-							<td><label for="preset_author_input"></label><input id="preset_author_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset author" value="MangoSynth"></td>
-							<td><label for="preset_rating_input"></label><input id="preset_rating_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset rating" value="0"></td>
-							<td class="flex justify-end mb-1">
-								<button id="preset_save_button" class="border border-blue-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center mr-1">Save Preset</button>
-								<button id="preset_download_button" class="border border-green-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center">Download Preset</button>
-							</td>
-						</tr>
-					</tbody>
-					<tbody id="presets_table_body">
-						<!--Presets auto-injected here-->
-					</tbody>
-				</table>
-				<hr class="mb-4 mt-4"/>
-				<div class="mb-2  flex justify-center">
-					<a id="preset_disk_load_button" class="flex cursor-pointer text-sm border border-gray-500 hover:border-white rounded-lg p-2 transition-all">
-						Load from disk
-					</a>
-					<input id="preset_file_input" class="hidden" type='file' />
+			<!--********************-->
+			<!--	  ROW TWO 	    -->
+			<!--********************-->
+			<div class="flex z-10">
+				<!--********************-->
+				<!--  SUB OSCILLATOR	-->
+				<!--********************-->
+				<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="flex justify-between mb-1">
+							<div class="flex flex-col">
+								<div class="flex p-1">
+									<webaudio-switch
+										id="osc_c_switch"
+										class="control toggleControl self-center pr-1"
+										colors="#A9DC76;#2C292D;#D9D9D9"
+										diameter="30"
+										value="0"
+									></webaudio-switch>
+									<p class="font-inika self-center">SUB OSC</p>
+								</div>
+								<div class="flex p-1">
+									<webaudio-switch
+										id="arp_c_switch"
+										class="control"
+										colors="#AB9DF2;#2C292D;#D9D9D9"
+										diameter="30"
+										value="0"
+									></webaudio-switch>
+									<p id="arp_c_label" class="font-inika ml-1">ARP</p>
+								</div>
+							</div>
+							<div class="self-center border border-gray-600 flex rounded-lg p-1">
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Voices</p>
+									<webaudio-knob
+										id="osc_c_voices"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="1"
+										max="24"
+										value="1"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_c_voices_readout"
+										link="osc_c_voices"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Spread</p>
+									<webaudio-knob
+										id="osc_c_spread"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="1"
+										max="100"
+										value="1"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_c_spread_readout"
+										link="osc_c_spread"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end mr-1 w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">AM</p>
+									<webaudio-knob
+										id="osc_c_am"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="50"
+										value="0"
+										step="1"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_c_am_readout"
+										link="osc_c_am"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+								<div class="border border-gray-600 rounded-lg py-1 flex flex-col self-end w-[50px]">
+									<p class="font-light text-sm self-center mb-0.5">Shape</p>
+									<webaudio-knob
+										id="osc_c_am_shape"
+										class="control subControl self-center"
+										colors="#FFFFFF;#2C292D;#D9D9D9"
+										diameter="30"
+										min="0"
+										max="3"
+										value="0"
+										step="1"
+										conv="['sin','tri','saw','sqr'][x]"
+									></webaudio-knob>
+									<webaudio-param
+										id="osc_c_am_shape_readout"
+										link="osc_c_am_shape"
+										class="self-center border border-gray-600 mt-1"
+										colors="#FFF;#000"
+										fontSize="10"
+										width="30"
+									></webaudio-param>
+								</div>
+							</div>
+						</div>
+						<div class="flex">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Octave</p>
+								<webaudio-knob
+									id="osc_c_octave"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="3"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_octave_readout"
+									link="osc_c_octave"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Detune</p>
+								<webaudio-knob
+									id="osc_c_semi"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-12"
+									max="12"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_semi_readout"
+									link="osc_c_semi"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Volume</p>
+								<webaudio-knob
+									id="osc_c_volume"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									diameter="50"
+									min="-10"
+									max="10"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_volume_readout"
+									link="osc_c_volume"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light self-center mb-0.5">Shape</p>
+								<webaudio-slider
+									id="osc_c_shape"
+									class="control mainControl4 self-center"
+									colors="#78DCE8;#2C292D;#D9D9D9"
+									height="50"
+									min="0"
+									max="3"
+									value="2"
+									direction="vert"
+									conv="['sine','triangle','sawtooth','square'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="osc_c_shape_readout"
+									link="osc_c_shape"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<!--right-->
+					<div class="flex flex-col">
+						<div class="self-center border border-gray-600 flex rounded-lg p-1 mb-1">
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">ATK</p>
+								<webaudio-knob
+									id="osc_c_attack"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.005"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_attack_readout"
+									link="osc_c_attack"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">DEC</p>
+								<webaudio-knob
+									id="osc_c_decay"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="2"
+									value="0.1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_decay_readout"
+									link="osc_c_decay"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px] mr-1">
+								<p class="font-light text-sm self-center mb-0.5">SUS</p>
+								<webaudio-knob
+									id="osc_c_sustain"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="1"
+									value="0.3"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_sustain_readout"
+									link="osc_c_sustain"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg py-1 flex flex-col w-[50px]">
+								<p class="font-light text-sm self-center mb-0.5">REL</p>
+								<webaudio-knob
+									id="osc_c_release"
+									class="control adsrControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									diameter="30"
+									min="0"
+									max="5"
+									value="1"
+									step="0.001"
+								></webaudio-knob>
+								<webaudio-param
+									id="osc_c_release_readout"
+									link="osc_c_release"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="30"
+								></webaudio-param>
+							</div>
+						</div>
+						<div id="osc_c_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="osc_c_canvas" width="212" height="102"></canvas>
+						</div>
+					</div>
+				</div>
+				<!--********************-->
+				<!--   FM VISUALISER 	-->
+				<!--********************-->
+				<div class="self-center border border-gray-600 flex rounded-lg p-1 mx-1 z-10">
+					<canvas class="self-center" id="fm_canvas" width="51" height="50"></canvas>
+				</div>
+				<!--********************-->
+				<!--    MULTI FILTER    -->
+				<!--********************-->
+				<div class="self-center border border-gray-600 border-b-0 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="h-[98px] mb-1">
+							<div class="flex p-1">
+								<webaudio-switch
+									id="filter_switch"
+									class="control toggleControl self-center pr-1"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="30"
+									value="1"
+								></webaudio-switch>
+								<p class="font-inika self-center">FILTER</p>
+							</div>
+						</div>
+
+						<div class="flex">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Cutoff</p>
+								<webaudio-knob
+									id="filter_cutoff"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="5"
+									max="10000"
+									value="5000"
+									step="5"
+								></webaudio-knob>
+								<webaudio-param
+									id="filter_cutoff_readout"
+									link="filter_cutoff"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div id="filter_resonance_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
+								<webaudio-knob
+									id="filter_resonance"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="1"
+									max="10"
+									value="0"
+									step="0.1"
+								></webaudio-knob>
+								<webaudio-param
+									id="filter_resonance_readout"
+									link="filter_resonance"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Rolloff</p>
+								<webaudio-slider
+									id="filter_rolloff"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									height="50"
+									min="0"
+									max="3"
+									step="1"
+									direction="vert"
+									conv="['-12','-24','-48','-96'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="filter_rolloff_readout"
+									link="filter_rolloff"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light self-center mb-0.5">Type</p>
+								<webaudio-slider
+									id="filter_type"
+									class="control mainControl4 self-center"
+									colors="#78DCE8;#2C292D;#D9D9D9"
+									height="50"
+									min="0"
+									max="6"
+									step="1"
+									value="0"
+									direction="vert"
+									conv="['LPF','HPF','BPF','APF','Notch','LSF','HSF'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="filter_type_readout"
+									link="filter_type"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<!--right-->
+					<div class="flex flex-col justify-center">
+						<div class="self-center border border-gray-600 flex justify-around rounded-lg p-1 mb-1 w-[222px] h-[98px]">
+							<div class="p-0.5 w-min flex flex-col justify-center">
+								<p class="font-light text-sm self-center w-max">Send A</p>
+								<webaudio-switch
+									id="osc_a_filter_switch"
+									class="control toggleControl self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="30"
+									value="1"
+								></webaudio-switch>
+							</div>
+							<div class="p-0.5 w-min flex flex-col justify-center">
+								<p class="font-light text-sm self-center w-max">Send B</p>
+								<webaudio-switch
+									id="osc_b_filter_switch"
+									class="control toggleControl self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="30"
+									value="1"
+								></webaudio-switch>
+							</div>
+							<div class="p-0.5 w-min flex flex-col justify-center">
+								<p class="font-light text-sm self-center w-max">Send C</p>
+								<webaudio-switch
+									id="osc_c_filter_switch"
+									class="control toggleControl self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="30"
+									value="1"
+								></webaudio-switch>
+							</div>
+						</div>
+						<div class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="filter_canvas" width="212" height="102"></canvas>
+						</div>
+					</div>
+				</div>
+			</div>
+			<!--********************-->
+			<!--	 ROW THREE 	    -->
+			<!--********************-->
+			<div class="flex z-10">
+				<!--********************-->
+				<!--   LOW FREQ OSC 	-->
+				<!--********************-->
+				<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="flex p-1">
+							<webaudio-switch
+								id="lfo_switch"
+								class="control toggleControl self-center pr-1"
+								colors="#A9DC76;#2C292D;#D9D9D9"
+								diameter="30"
+								value="0"
+							></webaudio-switch>
+							<label class="font-inika self-center" for="lfo_selector">
+								LFO
+								&nbsp;
+								<select
+									id="lfo_selector"
+									class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
+									autocomplete="off"
+								>
+									<option value="FilterFrequency" selected="selected">Filter Frequency</option>
+									<option value="OscAVol">OSC A Volume</option>
+									<option value="OscBVol">OSC B Volume</option>
+									<option value="OscCVol">OSC C Volume</option>
+								</select>
+							</label>
+						</div>
+						<div class="flex">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Grid</p>
+								<webaudio-knob
+									id="lfo_grid"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="9"
+									value="5"
+									step="1"
+									conv="['8/1','4/1','2/1','1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
+								></webaudio-knob>
+								<webaudio-param
+									id="lfo_grid_readout"
+									link="lfo_grid"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Min</p>
+								<webaudio-knob
+									id="lfo_min"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="10000"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="lfo_min_readout"
+									link="lfo_min"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p class="font-light self-center mb-0.5">Max</p>
+								<webaudio-knob
+									id="lfo_max"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="10000"
+									value="1000"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="lfo_max_readout"
+									link="lfo_max"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light self-center mb-0.5">Shape</p>
+								<webaudio-slider
+									id="lfo_shape"
+									class="control mainControl4 self-center"
+									colors="#78DCE8;#2C292D;#D9D9D9"
+									height="50"
+									min="0"
+									max="3"
+									step="1"
+									value="0"
+									direction="vert"
+									conv="['sine','triangle','sawtooth','square'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="lfo_shape_readout"
+									link="lfo_shape"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<!--right-->
+					<div>
+						<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
+						<div class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="lfo_canvas" width="212" height="102"></canvas>
+						</div>
+					</div>
+				</div>
+				<!--************-->
+				<!--   MIDDLE 	-->
+				<!--************-->
+				<div class="self-center w-[61px] mx-1 z-10"></div>
+				<!--********************-->
+				<!--     MULTI FX       -->
+				<!--********************-->
+				<div class="self-center border border-gray-600 rounded-lg p-1 flex z-10">
+					<!--left-->
+					<div class="flex flex-col justify-between mr-1">
+						<div class="flex p-1">
+							<webaudio-switch
+								id="fx_switch"
+								class="control toggleControl self-center pr-1"
+								colors="#A9DC76;#2C292D;#D9D9D9"
+								diameter="30"
+								value="1"
+							></webaudio-switch>
+							<label class="font-inika self-center" for="fx_selector">
+								FX
+								&nbsp;
+								<select
+									id="fx_selector"
+									class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
+									autocomplete="off"
+								>
+									<option value="Distortion" selected="selected">Distortion</option>
+									<option value="Chebyshev">Chebyshev Distortion</option>
+									<option value="Phaser">Phaser</option>
+									<option value="Tremolo">Tremolo</option>
+									<option value="Vibrato">Vibrato</option>
+									<option value="Delay">Delay</option>
+									<option value="Reverb">Reverb</option>
+									<option value="PitchShift">Pitch Shift</option>
+									<option value="FreqShift">Freq Shift</option>
+								</select>
+							</label>
+						</div>
+						<div class="flex w-[372px]">
+							<div id="fx_param1_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p id="fx_param1_label" class="font-light self-center mb-0.5">Intensity</p>
+								<webaudio-knob
+									id="fx_param1"
+									class="control mainControl1 self-center"
+									colors="#FF6188;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="20"
+									value="0"
+									step="0.1"
+								></webaudio-knob>
+								<webaudio-param
+									id="fx_param1_readout"
+									link="fx_param1"
+									fontSize="14"
+									width="60"
+									class="self-center border border-pink-800 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div id="fx_param2_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p id="fx_param2_label" class="font-light self-center mb-0.5">Oversample</p>
+								<webaudio-knob
+									id="fx_param2"
+									class="control mainControl2 self-center"
+									colors="#A9DC76;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="2"
+									value="0"
+									step="1"
+								></webaudio-knob>
+								<webaudio-param
+									id="fx_param2_readout"
+									link="fx_param2"
+									fontSize="14"
+									width="60"
+									class="self-center border border-green-700 mt-1"
+									colors="#FFF;#000"
+								></webaudio-param>
+							</div>
+							<div id="fx_param3_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
+								<p id="fx_param3_label" class="font-light self-center mb-0.5">Mix</p>
+								<webaudio-knob
+									id="fx_param3"
+									class="control mainControl3 self-center"
+									colors="#FFD866;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="1"
+									step=".01"
+									value="0.5"
+								></webaudio-knob>
+								<webaudio-param
+									id="fx_param3_readout"
+									link="fx_param3"
+									class="self-center border border-yellow-600 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+							<div id="fx_param4_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] hidden">
+								<p id="fx_param4_label" class="font-light self-center mb-0.5">Mix</p>
+								<webaudio-knob
+									id="fx_param4"
+									class="control mainControl4 self-center"
+									colors="#78DCE8;#2C292D;#D9D9D9"
+									diameter="50"
+									min="0"
+									max="1"
+									step=".01"
+									value="0.5"
+								></webaudio-knob>
+								<webaudio-param
+									id="fx_param4_readout"
+									link="fx_param4"
+									class="self-center border border-cyan-700 mt-1"
+									colors="#FFF;#000"
+									fontSize="14"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+					</div>
+					<!--right-->
+					<div class="flex flex-col justify-center">
+						<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
+						<div class="self-center border border-gray-600 flex rounded-lg p-1">
+							<canvas class="self-center" id="fx_canvas" width="212" height="102"></canvas>
+						</div>
+					</div>
+				</div>
+			</div>
+			<!--********************-->
+			<!-- 	  KEYBOARD 	    -->
+			<!--********************-->
+			<div class="flex justify-center p-1 z-10 border border-gray-600 border-t-0 rounded-lg">
+				<div class="w-full flex justify-between z-10">
+					<div class="flex">
+						<div class="flex flex-col mr-1 z-10">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light text-sm self-center mb-0.5">Pattern</p>
+								<webaudio-slider
+									id="arp_pattern"
+									class="control arpControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									min="0"
+									max="8"
+									value="0"
+									direction="vert"
+									height="50"
+									conv="['up','down','upDown','downUp','alternateUp','alternateDown','random','randomOnce','randomWalk'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="arp_pattern_readout"
+									link="arp_pattern"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+						<div class="flex flex-col mr-1 z-10">
+							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+								<p class="font-light text-sm self-center mb-0.5">Speed</p>
+								<webaudio-slider
+									id="arp_speed"
+									class="control arpControl self-center"
+									colors="#AB9DF2;#2C292D;#D9D9D9"
+									min="0"
+									max="6"
+									value="3"
+									direction="vert"
+									height="50"
+									conv="['1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
+								></webaudio-slider>
+								<webaudio-param
+									id="arp_speed_readout"
+									link="arp_speed"
+									class="self-center border border-violet-900 mt-1"
+									colors="#FFF;#000"
+									fontSize="10"
+									width="60"
+								></webaudio-param>
+							</div>
+						</div>
+						<div class="p-1 flex flex-col w-[90px] mr-1"></div>
+						<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px]">
+							<p class="font-light text-sm self-center mb-0.5">Octave</p>
+							<webaudio-slider
+								id="master_octave"
+								class="control masterControl self-center"
+								colors="#FFFFFF;#2C292D;#D9D9D9"
+								min="0"
+								max="4"
+								value="2"
+								direction="vert"
+								height="50"
+								conv="['-2','-1','0','+1','+2'][x]"
+							></webaudio-slider>
+							<webaudio-param
+								id="master_octave_readout"
+								link="master_octave"
+								class="self-center border border-gray-600 mt-1"
+								colors="#FFF;#000"
+								fontSize="10"
+								width="60"
+							></webaudio-param>
+						</div>
+					</div>
+				</div>
+				<div class="border border-gray-600 rounded-lg self-center p-2 mx-1 z-10">
+					<webaudio-keyboard
+						id="keyboard"
+						keys="61"
+						height="85"
+						width="510"
+						class="self-center"
+					></webaudio-keyboard>
+				</div>
+				<div class="w-full flex flex-col z-10">
+					<div class="h-full self-end flex items-end">
+						<p id="rec_label" class="mr-1">Record</p>
+						<webaudio-switch
+							id="rec_switch"
+							class="control"
+							colors="#FF6188;#2C292D;#D9D9D9"
+							diameter="30"
+							value="0"
+						></webaudio-switch>
+					</div>
 				</div>
 			</div>
 		</div>
-	</main>
+		<div id="presets_container" class="hidden w-[1285px] border border-gray-600 border-t-0 rounded-xl rounded-tl-none rounded-tr-none p-1">
+			<!--Presets table: name/type/author/rating/load-->
+			<table id="presets_table" class="table-auto w-full">
+				<thead>
+				<tr class="text-left font-inika">
+					<th class="font-light">Name</th>
+					<th class="font-light">Type</th>
+					<th class="font-light">Author</th>
+					<th class="font-light">Rating</th>
+					<th></th>
+				</tr>
+				</thead>
+				<tbody id="preset_save_body">
+				<tr id="preset_save_row">
+					<td><label for="preset_name_input"></label><input id="preset_name_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset name" value="Init"></td>
+					<td><label for="preset_type_input"></label><input id="preset_type_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset type" value="Default"></td>
+					<td><label for="preset_author_input"></label><input id="preset_author_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset author" value="MangoSynth"></td>
+					<td><label for="preset_rating_input"></label><input id="preset_rating_input" class="bg-custom-black text-gray-300 border border-white rounded-lg p-1" type="text" placeholder="Preset rating" value="0"></td>
+					<td class="flex justify-end mb-1">
+						<button id="preset_save_button" class="border border-blue-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center mr-1">Save Preset</button>
+						<button id="preset_download_button" class="border border-green-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center">Download Preset</button>
+					</td>
+				</tr>
+				</tbody>
+				<tbody id="presets_table_body">
+				<!--Presets auto-injected here-->
+				</tbody>
+			</table>
+			<hr class="mb-4 mt-4"/>
+			<div class="mb-2  flex justify-center">
+				<a id="preset_disk_load_button" class="flex cursor-pointer text-sm border border-gray-500 hover:border-white rounded-lg p-2 transition-all">
+					Load from disk
+				</a>
+				<input id="preset_file_input" class="hidden" type='file' />
+			</div>
+		</div>
+	</div>
+</main>
 </body>
 </html>

--- a/src/synth.js
+++ b/src/synth.js
@@ -1120,7 +1120,7 @@ settingsThemeButton.addEventListener("click", function () {
 		SYNTH.THEME.current = "light"
 		// Update page colours
 		updatePageColours("#555", "#999", "#000", "light")
-		updateControlColours("masterControl", "#FFFFFF", "#000", "#FFFFFF")
+		updateControlColours("masterControl", "#000", "#FFFFFF", "#FFFFFF")
 		updateControlColours("toggleControl", "#A9DC76", "#2C292D", "#D9D9D9")
 		updateControlColours("subControl", "#000", "#FFFFFF", "#FFFFFF")
 		updateControlColours("mainControl1", "#000", "#FF6188", "#FFFFFF")
@@ -1128,6 +1128,8 @@ settingsThemeButton.addEventListener("click", function () {
 		updateControlColours("mainControl3", "#000", "#FFD866", "#FFFFFF")
 		updateControlColours("mainControl4", "#000", "#78DCE8", "#FFFFFF")
 		updateControlColours("adsrControl", "#000", "#AB9DF2", "#FFFFFF")
+		updateControlColours("arpControl", "#000", "#AB9DF2", "#FFFFFF")
+		updateParamColours("#000", "#ccc")
 		// Replace classes
 		// updateHtmlClasses("bg-gray-700", "bg-pink-500")
 		// updateHtmlClasses("hover:bg-gray-600", "hover:bg-pink-800")
@@ -1155,6 +1157,8 @@ settingsThemeButton.addEventListener("click", function () {
 		updateControlColours("mainControl3", "#FFD866", "#2C292D", "#D9D9D9")
 		updateControlColours("mainControl4", "#78DCE8", "#2C292D", "#D9D9D9")
 		updateControlColours("adsrControl", "#AB9DF2", "#2C292D", "#D9D9D9")
+		updateControlColours("arpControl", "#AB9DF2", "#2C292D", "#D9D9D9")
+		updateParamColours("#FFF", "#000")
 		// Replace classes
 		// updateHtmlClasses("bg-gray-50", "bg-gray-700")
 		updateHtmlClasses("border-gray-100", "border-gray-500")
@@ -1676,6 +1680,25 @@ function updateControlColours(targetClass, indicator, background, highlight){
 	$(jQtargetGroup).each(function(){
 		$(this)[0].colors = `${indicator};${background};${highlight}`
 	})
+}
+function updateParamColours(textColor, backgroundColor){
+	/*
+	for(let i = 0; i < targets.length; i++){
+		console.log(targets[i])
+		let target = "#"+targets[i].id
+		console.log("Updating colour of", target, "to", textColor+";"+backgroundColor)
+		$(target)[0].colors = `${textColor};${backgroundColor}`
+		console.log(targets[i])
+	}
+	*/
+	for(let i = 0; i < webaudioControlsReadouts.length; i++){
+		console.log("Updating colour of", webaudioControlsReadouts[i])
+		let width = webaudioControlsReadouts[i].width
+		let fontSize = webaudioControlsReadouts[i].fontsize
+		webaudioControlsReadouts[i]
+			.shadowRoot.querySelector("input")
+			.setAttribute("style", `color: ${textColor}; background-color: ${backgroundColor}; width: ${width}px; height: 20px; font-size: ${fontSize}px;`)
+	}
 }
 let infoBlocks = document.getElementsByClassName("info_block")
 let lfoSelector = document.getElementById("lfo_selector")

--- a/src/synth.js
+++ b/src/synth.js
@@ -3086,7 +3086,7 @@ let firstEntry = true
 consentButton.addEventListener("click", function () {
 	consentContainer.style.display = "none";
 	synthContainer.style.display = "flex";
-	bodyContainer.style.paddingTop = "2rem";
+	bodyContainer.style.paddingTop = "1rem";
 	document.body.style.backgroundColor = SYNTH.THEME.pageBackgroundColour;
 	if (Tone.context.state !== "running") {
 		Tone.context.resume();

--- a/src/synth.js
+++ b/src/synth.js
@@ -37,6 +37,8 @@ Tone.Transport.start()
 let SYNTH = {
 	STATE: {
 		enabled: false,
+		settingsDropdownOpen: false,
+		presetsPageOpen: false,
 		physicalKeyboardActive: true,
 		isPlaying: false,
 		keysHeld: 0,
@@ -47,7 +49,7 @@ let SYNTH = {
 		arp_C_frequencies: []
 	},
 	THEME: {
-		name: "dark",
+		current: "dark",
 		pageBackgroundColour: "#000",
 		synthBackgroundColour: "#242424",
 		synthTextColour: "#FFFFFF",
@@ -1012,6 +1014,7 @@ function fxGroupUpdate(switchTarget){
 
 // Top-row elements //
 let synthBody = document.getElementById("synth_body")
+let topRowContainer = document.getElementById("top_row_container")
 let presetsContainer = document.getElementById("presets_container")
 let presetsButton = document.getElementById("presets_button")
 let presetDiskLoadButton = document.getElementById("preset_disk_load_button")
@@ -1025,11 +1028,8 @@ let fileInput = document.getElementById("preset_file_input")
 let settingsButton = document.getElementById("settings_button")
 let settingsDropdown = document.getElementById("settings_dropdown")
 let settingsThemeButton = document.getElementById("settings_theme_button")
+let settingsHomeButton = document.getElementById("settings_home_button");
 let randomButton = document.getElementById("random_preset_button")
-
-// Dropdown states
-let settingsDropdownOpen = 0
-let presetsPageOpen = 0
 
 // Functions for top-row buttons
 function toggleDropdown(target) {
@@ -1039,7 +1039,7 @@ function toggleDropdown(target) {
 		target.classList.add("hidden")
 	}
 	if (target === settingsDropdown) {
-		settingsDropdownOpen = !settingsDropdownOpen
+		SYNTH.STATE.settingsDropdownOpen = !SYNTH.STATE.settingsDropdownOpen
 	}
 }
 function togglePresetsPage() {
@@ -1047,42 +1047,59 @@ function togglePresetsPage() {
 	SYNTH_A.releaseAll()
 	SYNTH_B.releaseAll()
 	SYNTH_C.releaseAll()
-	if (!presetsPageOpen) {
+	if (!SYNTH.STATE.presetsPageOpen) {
 		// hide synthBody and p5_canvas
 		synthBody.classList.add("hidden")
 		p5_canvas.classList.add("hidden");
 		// show presetsContainer
 		presetsContainer.classList.remove("hidden")
+		// change topRowContainer border styling
+		topRowContainer.classList.add("rounded-br-none", "rounded-bl-none")
 	} else {
 		// show synthBody and p5_canvas
 		synthBody.classList.remove("hidden")
 		p5_canvas.classList.remove("hidden");
 		// hide presetsContainer
 		presetsContainer.classList.add("hidden")
+		// undo topRowContainer border styling
+		topRowContainer.classList.remove("rounded-br-none", "rounded-bl-none")
 	}
-	presetsPageOpen = !presetsPageOpen
+	SYNTH.STATE.presetsPageOpen = !SYNTH.STATE.presetsPageOpen
 }
 
 // Event listeners for top-row buttons
 settingsButton.addEventListener("click", function () {
 	toggleDropdown(settingsDropdown)
 })
+presetsButton.addEventListener("click", function () {
+	togglePresetsPage()
+	if(SYNTH.STATE.settingsDropdownOpen){
+		toggleDropdown(settingsDropdown)
+	}
+})
+randomButton.addEventListener("click", function () {
+	console.log("This button will return a randomized preset!")
+})
+
+// Function which loops through all elements on the page, goes through each classList, and changes the colours
+function updateHtmlClasses(targetClass, newClass) {
+	let targetElements = document.getElementsByClassName(targetClass)
+	console.log(targetElements.length + " elements found with class '" + targetClass + "'" + "\nChanging to '" + newClass + "'")
+	while(targetElements.length > 0) {
+		targetElements.item(0).classList.add(newClass)
+		targetElements[0].classList.remove(targetClass)
+	}
+}
+
+// Event listeners for settings dropdown
 settingsThemeButton.addEventListener("click", function () {
-	console.log("Changing theme!")
-	if(SYNTH.THEME.name==="light"){
-		SYNTH.THEME.name = "dark"
-		updatePageColours("#111", "#242424", "#fff", "dark")
-		// #FFFFFF;#2C292D;#D9D9D9
-		updateControlColours("masterControl", "#FFFFFF", "#2C292D", "#D9D9D9")
-		updateControlColours("toggleControl", "#A9DC76", "#2C292D", "#D9D9D9")
-		updateControlColours("subControl", "#FFFFFF", "#2C292D", "#D9D9D9")
-		updateControlColours("mainControl1", "#FF6188", "#2C292D", "#D9D9D9")
-		updateControlColours("mainControl2", "#A9DC76", "#2C292D", "#D9D9D9")
-		updateControlColours("mainControl3", "#FFD866", "#2C292D", "#D9D9D9")
-		updateControlColours("mainControl4", "#78DCE8", "#2C292D", "#D9D9D9")
-		updateControlColours("adsrControl", "#AB9DF2", "#2C292D", "#D9D9D9")
-	} else {
-		SYNTH.THEME.name = "light"
+
+	// toggleDropdown(settingsDropdown)
+	if (SYNTH.THEME.current === "dark") {
+		console.log("Changing theme from " + SYNTH.THEME.current + " to light")
+		// Set theme to light
+		SYNTH.THEME.current = "light"
+		// Update page colours
 		updatePageColours("#555", "#999", "#000", "light")
 		updateControlColours("masterControl", "#FFFFFF", "#000", "#FFFFFF")
 		updateControlColours("toggleControl", "#A9DC76", "#2C292D", "#D9D9D9")
@@ -1092,23 +1109,59 @@ settingsThemeButton.addEventListener("click", function () {
 		updateControlColours("mainControl3", "#000", "#FFD866", "#FFFFFF")
 		updateControlColours("mainControl4", "#000", "#78DCE8", "#FFFFFF")
 		updateControlColours("adsrControl", "#000", "#AB9DF2", "#FFFFFF")
+		// Replace classes
+		// updateHtmlClasses("bg-gray-700", "bg-pink-500")
+		// updateHtmlClasses("hover:bg-gray-600", "hover:bg-pink-800")
+		updateHtmlClasses("border-gray-500", "border-gray-100")
+		updateHtmlClasses("border-gray-600", "border-gray-200")
+		updateHtmlClasses("border-gray-700", "border-gray-300")
+		updateHtmlClasses("bg-stone-900", "bg-custom-white")
+		updateHtmlClasses("hover:bg-stone-600", "hover:bg-custom-white")
+		updateHtmlClasses("text-gray-300", "text-black")
+		updateHtmlClasses("bg-custom-black", "bg-custom-gray")
+		updateHtmlClasses("border-blue-400", "bg-blue-400")
+		updateHtmlClasses("border-red-400", "bg-red-400")
+		updateHtmlClasses("border-green-400", "bg-green-400")
+	} else {
+		console.log("Changing theme from " + SYNTH.THEME.current + " to dark")
+		// Set theme to dark
+		SYNTH.THEME.current = "dark"
+		// Update page colours
+		updatePageColours("#111", "#242424", "#fff", "dark")
+		updateControlColours("masterControl", "#FFFFFF", "#2C292D", "#D9D9D9")
+		updateControlColours("toggleControl", "#A9DC76", "#2C292D", "#D9D9D9")
+		updateControlColours("subControl", "#FFFFFF", "#2C292D", "#D9D9D9")
+		updateControlColours("mainControl1", "#FF6188", "#2C292D", "#D9D9D9")
+		updateControlColours("mainControl2", "#A9DC76", "#2C292D", "#D9D9D9")
+		updateControlColours("mainControl3", "#FFD866", "#2C292D", "#D9D9D9")
+		updateControlColours("mainControl4", "#78DCE8", "#2C292D", "#D9D9D9")
+		updateControlColours("adsrControl", "#AB9DF2", "#2C292D", "#D9D9D9")
+		// Replace classes
+		// updateHtmlClasses("bg-gray-50", "bg-gray-700")
+		updateHtmlClasses("border-gray-100", "border-gray-500")
+		updateHtmlClasses("border-gray-200", "border-gray-600")
+		updateHtmlClasses("border-gray-300", "border-gray-700")
+		updateHtmlClasses("bg-custom-white", "bg-stone-900")
+		updateHtmlClasses("hover:bg-custom-white", "hover:bg-stone-600")
+		updateHtmlClasses("text-black", "text-gray-300")
+		updateHtmlClasses("bg-custom-gray", "bg-custom-black")
+		updateHtmlClasses("bg-blue-400", "border-blue-400")
+		updateHtmlClasses("bg-red-400", "border-red-400")
+		updateHtmlClasses("bg-green-400", "border-green-400")
 	}
 })
-presetsButton.addEventListener("click", function () {
-	togglePresetsPage()
-	if(settingsDropdownOpen){
+settingsHomeButton.addEventListener("click", function () {
+	SYNTH.STATE.enabled = false;
+	consentContainer.style.display = "flex";
+	synthContainer.style.display = "none";
+	bodyContainer.style.paddingTop = "0rem";
+	document.body.style.backgroundColor = SYNTH.THEME.synthBackgroundColour;
+	p5_canvas.classList.add("hidden");
+	if(SYNTH.STATE.settingsDropdownOpen){
 		toggleDropdown(settingsDropdown)
 	}
 })
-randomButton.addEventListener("click", function () {
-	console.log("This button will return a randomized preset!")
-})
 
-// Event listeners for settings dropdown
-settingsThemeButton.addEventListener("click", function () {
-	console.log("This button will change the theme!")
-	toggleDropdown(settingsDropdown)
-})
 // Event listeners for presets page
 presetSaveButton.addEventListener("click", function() {
 	savePreset(PRESET)
@@ -1174,7 +1227,7 @@ function loadPreset(preset) {
 	PRESET = preset
 	console.log("Preset loaded:", preset.METADATA.name)
 	// Close presets page if open
-	if(presetsPageOpen) {
+	if(SYNTH.STATE.presetsPageOpen) {
 		togglePresetsPage()
 	}
 	// Set input fields
@@ -1447,6 +1500,7 @@ checkForPresets()
 function populatePresetsTable(){
 	let presetsTableBody = document.getElementById("presets_table_body")
 	let presetsTableBodyHTML = ""
+	let bgState = 0
 	for(let i = 0; i < localStorage.length; i++) {
 		if (localStorage.key(i).includes("preset-")) {
 			let preset = JSON.parse(localStorage.getItem(localStorage.key(i)))
@@ -1459,24 +1513,79 @@ function populatePresetsTable(){
 			if(preset.METADATA.rating === ""){
 				preset.METADATA.rating = "?"
 			}
-			presetsTableBodyHTML += `
-	        <tr class="text-left">
-	            <td>${preset.METADATA.name}</td>
-	            <td>${preset.METADATA.type}</td>
-	            <td>${preset.METADATA.author}</td>
-	            <td>${preset.METADATA.rating}</td>
-	            <td class="text-right">
-	                <button class="preset_load_button bg-gray-700 text-gray-300 rounded-lg p-1" id="${localStorage.key(i)}-load-button">
-	                Load
+			if(bgState === 0 && SYNTH.THEME.current === "dark") {
+				presetsTableBodyHTML += `
+	        <tr class="text-left bg-stone-900 h-[45px]">
+	            <td><span class="ml-1">${preset.METADATA.name}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.type}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.author}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.rating}</span></td>
+	            <td class="flex justify-end mt-1">
+	                <button class="preset_load_button border border-blue-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center mr-1" id="${localStorage.key(i)}-load-button">
+	                Load Preset
 	                </button>
-	            </td>
-	            <td class="text-right">
-	                <button class="preset_delete_button bg-gray-700 text-gray-300 rounded-lg p-1" id="${localStorage.key(i)}-delete-button">
-	                Delete
+	                <button class="preset_delete_button border border-red-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center" id="${localStorage.key(i)}-delete-button">
+	                Delete Preset
 	                </button>
 	            </td>
 	        </tr>
         	`
+				bgState++
+			} else if (bgState === 0 && SYNTH.THEME.current === "light") {
+				presetsTableBodyHTML += `
+	        <tr class="text-left bg-custom-white h-[45px]">
+	            <td><span class="ml-1">${preset.METADATA.name}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.type}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.author}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.rating}</span></td>
+	            <td class="flex justify-end mt-1">
+	                <button class="preset_load_button border bg-blue-400 hover:border-white transition-all text-black rounded-lg p-1 w-[135px] text-center mr-1" id="${localStorage.key(i)}-load-button">
+	                Load Preset
+	                </button>
+	                <button class="preset_delete_button border bg-red-400 hover:border-white transition-all text-black rounded-lg p-1 w-[135px] text-center" id="${localStorage.key(i)}-delete-button">
+	                Delete Preset
+	                </button>
+	            </td>
+	        </tr>
+        	`
+				bgState++
+			} else if (bgState === 1 && SYNTH.THEME.current === "dark") {
+				presetsTableBodyHTML += `
+	        <tr class="text-left h-[45px]">
+	            <td><span class="ml-1">${preset.METADATA.name}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.type}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.author}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.rating}</span></td>
+	            <td class="flex justify-end mt-1">
+	                <button class="preset_load_button border border-blue-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center mr-1" id="${localStorage.key(i)}-load-button">
+	                Load Preset
+	                </button>
+	                <button class="preset_delete_button border border-red-400 hover:border-white transition-all text-gray-300 rounded-lg p-1 w-[135px] text-center" id="${localStorage.key(i)}-delete-button">
+	                Delete Preset
+	                </button>
+	            </td>
+	        </tr>
+        	`
+				bgState--
+			} else if (bgState === 1 && SYNTH.THEME.current === "light") {
+				presetsTableBodyHTML += `
+	        <tr class="text-left h-[45px]">
+	            <td><span class="ml-1">${preset.METADATA.name}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.type}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.author}</span></td>
+	            <td><span class="ml-1">${preset.METADATA.rating}</span></td>
+	            <td class="flex justify-end mt-1">
+	                <button class="preset_load_button border bg-blue-400 hover:border-white transition-all text-black rounded-lg p-1 w-[135px] text-center mr-1" id="${localStorage.key(i)}-load-button">
+	                Load Preset
+	                </button>
+	                <button class="preset_delete_button border bg-red-400 hover:border-white transition-all text-black rounded-lg p-1 w-[135px] text-center" id="${localStorage.key(i)}-delete-button">
+	                Delete Preset
+	                </button>
+	            </td>
+	        </tr>
+			`
+				bgState--
+			}
 		}
 
 	}
@@ -3099,18 +3208,4 @@ consentButton.addEventListener("click", function () {
 		SYNTH.STATE.enabled = true;
 	}
 	p5_canvas.classList.remove("hidden");
-})
-
-let homeButton = document.getElementById("home_button");
-
-homeButton.addEventListener("click", function () {
-	SYNTH.STATE.enabled = false;
-	consentContainer.style.display = "flex";
-	synthContainer.style.display = "none";
-	bodyContainer.style.paddingTop = "0rem";
-	document.body.style.backgroundColor = SYNTH.THEME.synthBackgroundColour;
-	p5_canvas.classList.add("hidden");
-	if(settingsDropdownOpen){
-		toggleDropdown(settingsDropdown)
-	}
 })

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,6 +4,21 @@ module.exports = {
     files: ["*.{html, css, js}"],
     relative: true
   },
+  safelist: [
+    'bg-black',
+    'bg-white',
+    'bg-custom-white',
+    'hover:bg-custom-white',
+    'bg-custom-gray',
+    'bg-stone-900',
+    'border-blue-400',
+    'bg-blue-400',
+    'border-red-400',
+    'bg-red-400',
+    'bg-green-400',
+    'w-[135px]',
+    'h-[45px]',
+  ],
   theme: {
     extend: {
       fontFamily: {
@@ -23,8 +38,8 @@ module.exports = {
         "custom-black": "#242424",
         "custom-black-2": "#2F2F2F",
         "custom-purple": "#646CFF",
-        "custom-gray": "#EBEBEB99",
-        "custom-white": "#FFFFFFDE",
+        "custom-gray": "#999",
+        "custom-white": "#a8a8a8",
         // ...color-name: color-code (hex/hsl/rgb/rgba/hsla...)
       },
     },


### PR DESCRIPTION
### Why?
Ever since adding FM/AM controls to the oscillators, the synthesizer window was too big for the browser viewport.
This resulted in the GUI keyboard and bottom controls being obscured, which obviously isn't ideal!

### What's new?
- Master output oscilloscope (shows exactly what you hear!).
- LFO oscilloscope (a rough implementation, but an implementation nonetheless!).

### What's changed?
- The synth now fits within the browser viewport.
- Spacing & styling are now more uniform across the entire synth.
- Webaudio-knob sizes reduced to make more space.
- Visualisation areas shrunk to match new knob sizes.
- GUI keyboard is now shorter and slightly wider.
- P5 canvas has been re-aligned with synth.
- Oscilloscopes now match up with designated areas again.
- Theme-changing functionality improved, allowing for a much nicer (and lighter) light theme.