### PR TITLE
Feature/tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -1368,8 +1368,12 @@
 								></webaudio-switch>
 							</div>
 						</div>
-						<div class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="filter_canvas" width="212" height="102"></canvas>
+						<div class="self-center justify-center border border-gray-600 flex rounded-lg p-1 w-[222px] h-[102px]">
+							<div id="tooltips_container" class=" self-center text-center text-sm">
+								<p id="tooltip_top">Tooltips go here!</p>
+								<br/>
+								<p id="tooltip_bottom">Hover over something to see what it does!</p>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 					<button
 						id="settings_button"
 						class="
-							dropdownButton
+							dropdownButton tooltipElement
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
@@ -153,7 +153,7 @@
 					<button
 						id="presets_button"
 						class="
-							w-[75px]
+							tooltipElement w-[75px]
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
@@ -174,7 +174,8 @@
 				<div class="flex flex-col justify-center">
 					<button
 						id="random_preset_button"
-						class="w-[75px]
+						class="
+							tooltipElement w-[75px]
 							border border-gray-300 rounded-lg
 							px-2 pb-0 self-center hover:bg-stone-600
 							transition-all duration-300 ease-in-out">
@@ -230,7 +231,7 @@
 						<p id="master_bpm_label" class="text-center text-sm">BPM</p>
 						<webaudio-knob
 							id="master_bpm"
-							class="control masterControl self-center"
+							class="tooltipElement control masterControl self-center"
 							colors="#FFFFFF;#2C292D;#D9D9D9"
 							diameter="30"
 							min="1"
@@ -250,7 +251,7 @@
 						<p id="master_gain_label" class="text-center text-sm">Gain</p>
 						<webaudio-knob
 							id="master_gain"
-							class="control masterControl self-center"
+							class="tooltipElement control masterControl self-center"
 							colors="#FFFFFF;#2C292D;#D9D9D9"
 							diameter="30"
 							min="0"
@@ -286,22 +287,22 @@
 								<div class="flex p-1">
 									<webaudio-switch
 										id="osc_a_switch"
-										class="control toggleControl self-center pr-1"
+										class="tooltipElement control toggleControl self-center pr-1"
 										colors="#A9DC76;#2C292D;#D9D9D9"
 										diameter="30"
 										value="1"
 									></webaudio-switch>
-									<p class="font-inika self-center">OSC A</p>
+									<p id="osc_a_label" class="tooltipElement font-inika self-center">OSC A</p>
 								</div>
 								<div class="flex p-1">
 									<webaudio-switch
 										id="arp_a_switch"
-										class="control"
+										class="tooltipElement control"
 										colors="#AB9DF2;#2C292D;#D9D9D9"
 										diameter="30"
 										value="0"
 									></webaudio-switch>
-									<p id="arp_a_label" class="font-inika ml-1">ARP</p>
+									<p id="arp_a_label" class="tooltipElement font-inika ml-1">ARP</p>
 								</div>
 							</div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
@@ -309,7 +310,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Voices</p>
 									<webaudio-knob
 										id="osc_a_voices"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -330,7 +331,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Spread</p>
 									<webaudio-knob
 										id="osc_a_spread"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -351,7 +352,7 @@
 									<p class="font-light text-sm self-center mb-0.5">FM</p>
 									<webaudio-knob
 										id="osc_a_fm"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -372,7 +373,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Depth</p>
 									<webaudio-knob
 										id="osc_a_fm_depth"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -393,7 +394,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Shape</p>
 									<webaudio-knob
 										id="osc_a_fm_shape"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -418,7 +419,7 @@
 								<p class="font-light self-center mb-0.5">Octave</p>
 								<webaudio-knob
 									id="osc_a_octave"
-									class="control mainControl1 self-center"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-3"
@@ -439,7 +440,7 @@
 								<p class="font-light self-center mb-0.5">Detune</p>
 								<webaudio-knob
 									id="osc_a_semi"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-12"
@@ -460,7 +461,7 @@
 								<p class="font-light self-center mb-0.5">Volume</p>
 								<webaudio-knob
 									id="osc_a_volume"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-10"
@@ -481,7 +482,7 @@
 								<p class="font-light self-center mb-0.5">Shape</p>
 								<webaudio-slider
 									id="osc_a_shape"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -507,7 +508,7 @@
 								<p class="font-light text-sm self-center mb-0.5">ATK</p>
 								<webaudio-knob
 									id="osc_a_attack"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -528,7 +529,7 @@
 								<p class="font-light text-sm self-center mb-0.5">DEC</p>
 								<webaudio-knob
 									id="osc_a_decay"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -549,7 +550,7 @@
 								<p class="font-light text-sm self-center mb-0.5">SUS</p>
 								<webaudio-knob
 									id="osc_a_sustain"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -570,7 +571,7 @@
 								<p class="font-light text-sm self-center mb-0.5">REL</p>
 								<webaudio-knob
 									id="osc_a_release"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -589,7 +590,7 @@
 							</div>
 						</div>
 						<div id="osc_a_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="osc_a_canvas" width="212" height="102"></canvas>
+							<canvas class="tooltipElement self-center" id="oscilloscope_a" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
@@ -608,22 +609,22 @@
 								<div class="flex p-1">
 									<webaudio-switch
 										id="osc_b_switch"
-										class="control toggleControl self-center pr-1"
+										class="tooltipElement control toggleControl self-center pr-1"
 										colors="#A9DC76;#2C292D;#D9D9D9"
 										diameter="30"
 										value="0"
 									></webaudio-switch>
-									<p class="font-inika self-center">OSC B</p>
+									<p id="osc_b_label" class="tooltipElement font-inika self-center">OSC B</p>
 								</div>
 								<div class="flex p-1">
 									<webaudio-switch
 										id="arp_b_switch"
-										class="control"
+										class="tooltipElement control"
 										colors="#AB9DF2;#2C292D;#D9D9D9"
 										diameter="30"
 										value="0"
 									></webaudio-switch>
-									<p id="arp_b_label" class="font-inika ml-1">ARP</p>
+									<p id="arp_b_label" class="tooltipElement font-inika ml-1">ARP</p>
 								</div>
 							</div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
@@ -631,7 +632,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Voices</p>
 									<webaudio-knob
 										id="osc_b_voices"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -652,7 +653,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Spread</p>
 									<webaudio-knob
 										id="osc_b_spread"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -673,7 +674,7 @@
 									<p class="font-light text-sm self-center mb-0.5">FM</p>
 									<webaudio-knob
 										id="osc_b_fm"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -694,7 +695,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Depth</p>
 									<webaudio-knob
 										id="osc_b_fm_depth"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -715,7 +716,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Shape</p>
 									<webaudio-knob
 										id="osc_b_fm_shape"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -740,7 +741,7 @@
 								<p class="font-light self-center mb-0.5">Octave</p>
 								<webaudio-knob
 									id="osc_b_octave"
-									class="control mainControl1 self-center"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-3"
@@ -761,7 +762,7 @@
 								<p class="font-light self-center mb-0.5">Detune</p>
 								<webaudio-knob
 									id="osc_b_semi"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-12"
@@ -782,7 +783,7 @@
 								<p class="font-light self-center mb-0.5">Volume</p>
 								<webaudio-knob
 									id="osc_b_volume"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-10"
@@ -803,7 +804,7 @@
 								<p class="font-light self-center mb-0.5">Shape</p>
 								<webaudio-slider
 									id="osc_b_shape"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -830,7 +831,7 @@
 								<p class="font-light text-sm self-center mb-0.5">ATK</p>
 								<webaudio-knob
 									id="osc_b_attack"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -851,7 +852,7 @@
 								<p class="font-light text-sm self-center mb-0.5">DEC</p>
 								<webaudio-knob
 									id="osc_b_decay"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -872,7 +873,7 @@
 								<p class="font-light text-sm self-center mb-0.5">SUS</p>
 								<webaudio-knob
 									id="osc_b_sustain"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -893,7 +894,7 @@
 								<p class="font-light text-sm self-center mb-0.5">REL</p>
 								<webaudio-knob
 									id="osc_b_release"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -912,7 +913,7 @@
 							</div>
 						</div>
 						<div id="osc_b_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="osc_b_canvas" width="212" height="102"></canvas>
+							<canvas class="tooltipElement self-center" id="oscilloscope_b" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
@@ -932,22 +933,22 @@
 								<div class="flex p-1">
 									<webaudio-switch
 										id="osc_c_switch"
-										class="control toggleControl self-center pr-1"
+										class="tooltipElement control toggleControl self-center pr-1"
 										colors="#A9DC76;#2C292D;#D9D9D9"
 										diameter="30"
 										value="0"
 									></webaudio-switch>
-									<p class="font-inika self-center">SUB OSC</p>
+									<p id="osc_c_label" class="tooltipElement font-inika self-center">SUB OSC</p>
 								</div>
 								<div class="flex p-1">
 									<webaudio-switch
 										id="arp_c_switch"
-										class="control"
+										class="tooltipElement control"
 										colors="#AB9DF2;#2C292D;#D9D9D9"
 										diameter="30"
 										value="0"
 									></webaudio-switch>
-									<p id="arp_c_label" class="font-inika ml-1">ARP</p>
+									<p id="arp_c_label" class="tooltipElement font-inika ml-1">ARP</p>
 								</div>
 							</div>
 							<div class="self-center border border-gray-600 flex rounded-lg p-1">
@@ -955,7 +956,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Voices</p>
 									<webaudio-knob
 										id="osc_c_voices"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -976,7 +977,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Spread</p>
 									<webaudio-knob
 										id="osc_c_spread"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="1"
@@ -997,7 +998,7 @@
 									<p class="font-light text-sm self-center mb-0.5">AM</p>
 									<webaudio-knob
 										id="osc_c_am"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -1018,7 +1019,7 @@
 									<p class="font-light text-sm self-center mb-0.5">Shape</p>
 									<webaudio-knob
 										id="osc_c_am_shape"
-										class="control subControl self-center"
+										class="tooltipElement control subControl self-center"
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
@@ -1043,7 +1044,7 @@
 								<p class="font-light self-center mb-0.5">Octave</p>
 								<webaudio-knob
 									id="osc_c_octave"
-									class="control mainControl1 self-center"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1064,7 +1065,7 @@
 								<p class="font-light self-center mb-0.5">Detune</p>
 								<webaudio-knob
 									id="osc_c_semi"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-12"
@@ -1085,7 +1086,7 @@
 								<p class="font-light self-center mb-0.5">Volume</p>
 								<webaudio-knob
 									id="osc_c_volume"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									diameter="50"
 									min="-10"
@@ -1106,7 +1107,7 @@
 								<p class="font-light self-center mb-0.5">Shape</p>
 								<webaudio-slider
 									id="osc_c_shape"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -1133,7 +1134,7 @@
 								<p class="font-light text-sm self-center mb-0.5">ATK</p>
 								<webaudio-knob
 									id="osc_c_attack"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -1154,7 +1155,7 @@
 								<p class="font-light text-sm self-center mb-0.5">DEC</p>
 								<webaudio-knob
 									id="osc_c_decay"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -1175,7 +1176,7 @@
 								<p class="font-light text-sm self-center mb-0.5">SUS</p>
 								<webaudio-knob
 									id="osc_c_sustain"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -1196,7 +1197,7 @@
 								<p class="font-light text-sm self-center mb-0.5">REL</p>
 								<webaudio-knob
 									id="osc_c_release"
-									class="control adsrControl self-center"
+									class="tooltipElement control adsrControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									diameter="30"
 									min="0"
@@ -1215,7 +1216,7 @@
 							</div>
 						</div>
 						<div id="osc_c_canvas_container" class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="osc_c_canvas" width="212" height="102"></canvas>
+							<canvas class="tooltipElement self-center" id="oscilloscope_c" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
@@ -1235,12 +1236,12 @@
 							<div class="flex p-1">
 								<webaudio-switch
 									id="filter_switch"
-									class="control toggleControl self-center pr-1"
+									class="tooltipElement control toggleControl self-center pr-1"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="30"
 									value="1"
 								></webaudio-switch>
-								<p class="font-inika self-center">FILTER</p>
+								<p id="filter_label" class="tooltipElement font-inika self-center">FILTER</p>
 							</div>
 						</div>
 
@@ -1249,7 +1250,7 @@
 								<p class="font-light self-center mb-0.5">Cutoff</p>
 								<webaudio-knob
 									id="filter_cutoff"
-									class="control mainControl1 self-center"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="5"
@@ -1270,7 +1271,7 @@
 								<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
 								<webaudio-knob
 									id="filter_resonance"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="1"
@@ -1291,7 +1292,7 @@
 								<p class="font-light self-center mb-0.5">Rolloff</p>
 								<webaudio-slider
 									id="filter_rolloff"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -1313,7 +1314,7 @@
 								<p class="font-light self-center mb-0.5">Type</p>
 								<webaudio-slider
 									id="filter_type"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -1341,7 +1342,7 @@
 								<p class="font-light text-sm self-center w-max">Send A</p>
 								<webaudio-switch
 									id="osc_a_filter_switch"
-									class="control toggleControl self-center"
+									class="tooltipElement control toggleControl self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="30"
 									value="1"
@@ -1351,7 +1352,7 @@
 								<p class="font-light text-sm self-center w-max">Send B</p>
 								<webaudio-switch
 									id="osc_b_filter_switch"
-									class="control toggleControl self-center"
+									class="tooltipElement control toggleControl self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="30"
 									value="1"
@@ -1361,7 +1362,7 @@
 								<p class="font-light text-sm self-center w-max">Send C</p>
 								<webaudio-switch
 									id="osc_c_filter_switch"
-									class="control toggleControl self-center"
+									class="tooltipElement control toggleControl self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="30"
 									value="1"
@@ -1370,8 +1371,7 @@
 						</div>
 						<div class="self-center justify-center border border-gray-600 flex rounded-lg p-1 w-[222px] h-[102px]">
 							<div id="tooltips_container" class=" self-center text-center text-sm">
-								<p id="tooltip_top">Tooltips go here!</p>
-								<br/>
+								<p id="tooltip_top" class="font-bold">Tooltips go here :)</p>
 								<p id="tooltip_bottom">Hover over something to see what it does!</p>
 							</div>
 						</div>
@@ -1391,32 +1391,32 @@
 						<div class="flex p-1">
 							<webaudio-switch
 								id="lfo_switch"
-								class="control toggleControl self-center pr-1"
+								class="tooltipElement control toggleControl self-center pr-1"
 								colors="#A9DC76;#2C292D;#D9D9D9"
 								diameter="30"
 								value="0"
 							></webaudio-switch>
-							<label class="font-inika self-center" for="lfo_selector">
+							<label id="lfo_label" class="tooltipElement font-inika self-center" for="lfo_selector">
 								LFO
 								&nbsp;
-								<select
-									id="lfo_selector"
-									class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
-									autocomplete="off"
-								>
-									<option value="FilterFrequency" selected="selected">Filter Frequency</option>
-									<option value="OscAVol">OSC A Volume</option>
-									<option value="OscBVol">OSC B Volume</option>
-									<option value="OscCVol">OSC C Volume</option>
-								</select>
 							</label>
+							<select
+								id="lfo_selector"
+								class="tooltipElement control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
+								autocomplete="off"
+							>
+								<option value="FilterFrequency" selected="selected">Filter Frequency</option>
+								<option value="OscAVol">OSC A Volume</option>
+								<option value="OscBVol">OSC B Volume</option>
+								<option value="OscCVol">OSC C Volume</option>
+							</select>
 						</div>
 						<div class="flex">
 							<div class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-								<p class="font-light self-center mb-0.5">Grid</p>
+								<p class="font-light self-center mb-0.5">Rate</p>
 								<webaudio-knob
-									id="lfo_grid"
-									class="control mainControl1 self-center"
+									id="lfo_rate"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1426,8 +1426,8 @@
 									conv="['8/1','4/1','2/1','1/1','1/2','1/4','1/8','1/16','1/32','1/64'][x]"
 								></webaudio-knob>
 								<webaudio-param
-									id="lfo_grid_readout"
-									link="lfo_grid"
+									id="lfo_rate_readout"
+									link="lfo_rate"
 									fontSize="14"
 									width="60"
 									class="self-center border border-pink-800 mt-1"
@@ -1438,7 +1438,7 @@
 								<p class="font-light self-center mb-0.5">Min</p>
 								<webaudio-knob
 									id="lfo_min"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1459,7 +1459,7 @@
 								<p class="font-light self-center mb-0.5">Max</p>
 								<webaudio-knob
 									id="lfo_max"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1480,7 +1480,7 @@
 								<p class="font-light self-center mb-0.5">Shape</p>
 								<webaudio-slider
 									id="lfo_shape"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									height="50"
 									min="0"
@@ -1505,7 +1505,7 @@
 					<div>
 						<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 						<div class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="lfo_canvas" width="212" height="102"></canvas>
+							<canvas class="tooltipElement self-center" id="oscilloscope_lfo" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
@@ -1522,17 +1522,18 @@
 						<div class="flex p-1">
 							<webaudio-switch
 								id="fx_switch"
-								class="control toggleControl self-center pr-1"
+								class="tooltipElement control toggleControl self-center pr-1"
 								colors="#A9DC76;#2C292D;#D9D9D9"
 								diameter="30"
 								value="1"
 							></webaudio-switch>
-							<label class="font-inika self-center" for="fx_selector">
+							<label id="fx_label" class="tooltipElement font-inika self-center" for="fx_selector">
 								FX
 								&nbsp;
+							</label>
 								<select
 									id="fx_selector"
-									class="control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
+									class="tooltipElement control font-light bg-custom-black border border-gray-600 rounded-lg p-1 pl-3"
 									autocomplete="off"
 								>
 									<option value="Distortion" selected="selected">Distortion</option>
@@ -1545,14 +1546,13 @@
 									<option value="PitchShift">Pitch Shift</option>
 									<option value="FreqShift">Freq Shift</option>
 								</select>
-							</label>
 						</div>
 						<div class="flex w-[372px]">
 							<div id="fx_param1_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
 								<p id="fx_param1_label" class="font-light self-center mb-0.5">Intensity</p>
 								<webaudio-knob
 									id="fx_param1"
-									class="control mainControl1 self-center"
+									class="tooltipElement control mainControl1 self-center"
 									colors="#FF6188;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1573,7 +1573,7 @@
 								<p id="fx_param2_label" class="font-light self-center mb-0.5">Oversample</p>
 								<webaudio-knob
 									id="fx_param2"
-									class="control mainControl2 self-center"
+									class="tooltipElement control mainControl2 self-center"
 									colors="#A9DC76;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1594,7 +1594,7 @@
 								<p id="fx_param3_label" class="font-light self-center mb-0.5">Mix</p>
 								<webaudio-knob
 									id="fx_param3"
-									class="control mainControl3 self-center"
+									class="tooltipElement control mainControl3 self-center"
 									colors="#FFD866;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1615,7 +1615,7 @@
 								<p id="fx_param4_label" class="font-light self-center mb-0.5">Mix</p>
 								<webaudio-knob
 									id="fx_param4"
-									class="control mainControl4 self-center"
+									class="tooltipElement control mainControl4 self-center"
 									colors="#78DCE8;#2C292D;#D9D9D9"
 									diameter="50"
 									min="0"
@@ -1638,7 +1638,7 @@
 					<div class="flex flex-col justify-center">
 						<div class="self-center flex rounded-lg p-1 h-[100px] mb-1"></div>
 						<div class="self-center border border-gray-600 flex rounded-lg p-1">
-							<canvas class="self-center" id="fx_canvas" width="212" height="102"></canvas>
+							<canvas class="tooltipElement self-center" id="oscilloscope_master" width="212" height="102"></canvas>
 						</div>
 					</div>
 				</div>
@@ -1654,7 +1654,7 @@
 								<p class="font-light text-sm self-center mb-0.5">Pattern</p>
 								<webaudio-slider
 									id="arp_pattern"
-									class="control arpControl self-center"
+									class="tooltipElement control arpControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									min="0"
 									max="8"
@@ -1678,7 +1678,7 @@
 								<p class="font-light text-sm self-center mb-0.5">Speed</p>
 								<webaudio-slider
 									id="arp_speed"
-									class="control arpControl self-center"
+									class="tooltipElement control arpControl self-center"
 									colors="#AB9DF2;#2C292D;#D9D9D9"
 									min="0"
 									max="6"
@@ -1702,7 +1702,7 @@
 							<p class="font-light text-sm self-center mb-0.5">Octave</p>
 							<webaudio-slider
 								id="master_octave"
-								class="control masterControl self-center"
+								class="tooltipElement control masterControl self-center"
 								colors="#FFFFFF;#2C292D;#D9D9D9"
 								min="0"
 								max="4"
@@ -1728,7 +1728,7 @@
 						keys="61"
 						height="85"
 						width="510"
-						class="self-center"
+						class="tooltipElement self-center"
 					></webaudio-keyboard>
 				</div>
 				<div class="w-full flex flex-col z-10">
@@ -1736,7 +1736,7 @@
 						<p id="rec_label" class="mr-1">Record</p>
 						<webaudio-switch
 							id="rec_switch"
-							class="control"
+							class="tooltipElement control"
 							colors="#FF6188;#2C292D;#D9D9D9"
 							diameter="30"
 							value="0"

--- a/index.html
+++ b/index.html
@@ -356,9 +356,9 @@
 										colors="#FFFFFF;#2C292D;#D9D9D9"
 										diameter="30"
 										min="0"
-										max="50"
+										max="10"
 										value="0"
-										step="1"
+										step=".01"
 									></webaudio-knob>
 									<webaudio-param
 										id="osc_a_fm_readout"
@@ -379,7 +379,7 @@
 										min="0"
 										max="50"
 										value="0"
-										step="1"
+										step=".01"
 									></webaudio-knob>
 									<webaudio-param
 										id="osc_a_fm_depth_readout"
@@ -1268,7 +1268,7 @@
 								></webaudio-param>
 							</div>
 							<div id="filter_resonance_group" class="border border-gray-600 rounded-lg p-1 flex flex-col w-[90px] mr-1">
-								<p id="filter_resonance_label" class="font-light self-center mb-0.5">Q</p>
+								<p id="filter_resonance_label" class="font-light self-center mb-0.5">Resonance</p>
 								<webaudio-knob
 									id="filter_resonance"
 									class="tooltipElement control mainControl2 self-center"
@@ -1370,9 +1370,9 @@
 							</div>
 						</div>
 						<div class="self-center justify-center border border-gray-600 flex rounded-lg p-1 w-[222px] h-[102px]">
-							<div id="tooltips_container" class=" self-center text-center text-sm">
-								<p id="tooltip_top" class="font-bold">Tooltips go here :)</p>
-								<p id="tooltip_bottom">Hover over something to see what it does!</p>
+							<div id="tooltips_container" class="self-center text-center text-sm">
+								<p id="tooltip_top" class="font-bold">Tooltips go here!</p>
+								<p id="tooltip_bottom">Hover over something to see what it does &#128516;</p>
 							</div>
 						</div>
 					</div>

--- a/src/synth.js
+++ b/src/synth.js
@@ -1320,7 +1320,7 @@ function loadPreset(preset) {
 	// LFO
 	updateSelectBox("lfo_selector", PRESET.LFO.target)
 	updateGUI("lfo_switch", PRESET.LFO.enabled)
-	updateGUI("lfo_grid", PRESET.LFO.grid, lfoGridReadoutValues[PRESET.LFO.grid])
+	updateGUI("lfo_rate", PRESET.LFO.grid, lfoGridReadoutValues[PRESET.LFO.grid])
 	updateGUI("lfo_min", PRESET.LFO.min, PRESET.LFO.min)
 	updateGUI("lfo_max", PRESET.LFO.max, PRESET.LFO.max)
 	updateGUI("lfo_shape", PRESET.LFO.type, shapeValues[PRESET.LFO.type])
@@ -2402,7 +2402,7 @@ function changeNote(targetSynth, targetValue, newValue){
 // -- GUI CONTROLS LOGIC -- //
 
 let controls = document.getElementsByClassName("control");
-// console.log(controls);
+console.log(controls);
 
 // For each control...
 for (let i = 0; i < controls.length; i++) {
@@ -3036,7 +3036,7 @@ for (let i = 0; i < controls.length; i++) {
 				connectTone()
 				// LFO.connect(LFO_TARGET)
 				break;
-			case "lfo_grid":
+			case "lfo_rate":
 				PRESET.LFO.grid = e.target.value
 				LFO.set({
 					frequency: lfoGridValues[e.target.value]
@@ -3350,344 +3350,486 @@ consentButton.addEventListener("click", function () {
 
 // -- TOOLTIPS -- //
 
-// Buttons (Settings, Presets, Random)
+let tooltip_top = document.getElementById("tooltip_top");
+let tooltip_bottom = document.getElementById("tooltip_bottom");
+let tooltip_elements = document.getElementsByClassName("tooltipElement");
+
+for (let i = 0; i < tooltip_elements.length; i++) {
+	// Get the element's id
+	let element_id = tooltip_elements[i].id;
+	// Get the element's tag name
+	let element_tag = tooltip_elements[i].localName;
+	// Add mouseover event listener to each button
+	tooltip_elements[i].addEventListener("mouseover", function () {
+		// Log the element's tag and id
+		console.log("mouseover", element_tag, element_id)
+		// Get the tooltip text from the tooltips object
+		let tooltip
+		// If the first part of the id is "osc", and the element is a knob or slider
+		if (element_id.split("_")[0] === "osc" && element_tag === "webaudio-knob" || element_id.split("_")[0] === "osc" && element_tag === "webaudio-slider") {
+			// Log the id without the first two parts (e.g. "osc_a_fm_depth" becomes "fm_depth")
+			console.log(element_id.split("_").splice(2).join("_"))
+			// Use the id without the first two parts to get the correct tooltip text
+			// This is to reduce the amount of duplicate tooltip values
+			tooltip = tooltips[element_tag][element_id.split("_").splice(2).join("_")]
+		} else {
+			// Otherwise, just use the id to get the correct tooltip text
+			tooltip = tooltips[element_tag][element_id];
+		}
+		// Set the tooltip text
+		tooltip_top.innerHTML = tooltip.top;
+		tooltip_bottom.innerHTML = tooltip.bottom;
+	})
+	// Add mouseout event listener to each button
+	tooltip_elements[i].addEventListener("mouseout", function () {
+		console.log("mouseout", element_tag, element_id)
+		// Return the tooltip text to the default
+		tooltip_top.innerHTML = tooltips.defaults.top;
+		tooltip_bottom.innerHTML = tooltips.defaults.bottom;
+	})
+}
 
 let tooltips = {
-	Defaults: {
-		top: "Tooltips go here!",
+	defaults: {
+		top: "Tooltips go here :)",
 		bottom: "Hover over something to see what it does!"
 	},
 	// Buttons (Settings, Presets, Random)
-	Buttons: {
-		Settings: {
+	button: {
+		settings_button: {
 			top: "Change synth settings",
 			bottom: "Return home, or change the theme!"
 		},
-		Presets: {
+		presets_button: {
 			top: "Open the preset menu",
 			bottom: "Load a preset, or save your own!"
 		},
-		Random: {
+		random_preset_button: {
 			top: "Randomise the synth settings",
 			bottom: "Careful! This will overwrite your current settings!"
 		}
 	},
+	p: {
+		osc_a_label: {
+			top: "Oscillator A",
+			bottom: "Oscillators are the main sound generators in a synthesizer!"
+		},
+		arp_a_label: {
+			top: "Arpeggiator A",
+			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+		},
+		osc_b_label: {
+			top: "Oscillator B",
+			bottom: "Oscillators are the main sound generators in a synthesizer!"
+		},
+		arp_b_label: {
+			top: "Arpeggiator B",
+			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+		},
+		osc_c_label: {
+			top: "Oscillator C",
+			bottom: "Oscillators are the main sound generators in a synthesizer!"
+		},
+		arp_c_label: {
+			top: "Arpeggiator C",
+			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+		},
+		filter_label: {
+			top: "Filter",
+			bottom: "Filters shape the sound by cutting out certain frequencies!"
+		}
+	},
+	label: {
+		lfo_label: {
+			top: "LFO",
+			bottom: "LFOs (Low Frequency Oscillators) are used to automatically modulate parameters over time!"
+		},
+		fx_label: {
+			top: "FX",
+			bottom: "Choose from several effects to manipulate your sound with!"
+		},
+	},
 	// Switches (Groups, Arpeggiators, Sends, Record)
-	Switches: {
-		A: {
-			top: "Toggle oscillator A",
+	"webaudio-switch": {
+		osc_a_switch: {
+			top: "Toggle Oscillator A",
 			bottom: "This will turn the oscillator on or off"
 		},
-		B: {
-			top: "Toggle oscillator B",
+		arp_a_switch: {
+			top: "Toggle Arpeggiator A",
+			bottom: "This will turn the arpeggiator on or off"
+		},
+		osc_b_switch: {
+			top: "Toggle Oscillator B",
 			bottom: "This will turn the oscillator on or off"
 		},
-		C: {
-			top: "Toggle oscillator C",
+		arp_b_switch: {
+			top: "Toggle Arpeggiator B",
+			bottom: "This will turn the arpeggiator on or off"
+		},
+		osc_c_switch: {
+			top: "Toggle Oscillator C",
 			bottom: "This will turn the oscillator on or off"
 		},
-		Filter: {
-			top: "Toggle filter",
+		arp_c_switch: {
+			top: "Toggle Arpeggiator C",
+			bottom: "This will turn the arpeggiator on or off"
+		},
+		filter_switch: {
+			top: "Toggle Filter",
 			bottom: "This will turn the filter on or off"
 		},
-		FilterSend_A: {
+		osc_a_filter_switch: {
 			top: "Toggle filter for oscillator A",
 			bottom: "This will turn the filter on or off only for oscillator A"
 		},
-		FilterSend_B: {
+		osc_b_filter_switch: {
 			top: "Toggle filter for oscillator B",
 			bottom: "This will turn the filter on or off only for oscillator B"
 		},
-		FilterSend_C: {
+		osc_c_filter_switch: {
 			top: "Toggle filter for oscillator C",
 			bottom: "This will turn the filter on or off only for oscillator C"
 		},
-		LFO: {
+		lfo_switch: {
 			top: "Toggle LFO",
 			bottom: "This will turn the LFO on or off"
 		},
-		FX: {
+		fx_switch: {
 			top: "Toggle FX",
 			bottom: "This will turn the FX on or off"
 		},
-		Arpeggiator: {
-			top: "Toggle arpeggiator (for this oscillator)",
-			bottom: "This will turn the arpeggiator on or off"
+		rec_switch: {
+			top: "Toggle recording",
+			bottom: "This will start or stop recording the synth output"
 		}
 	},
 	// Controls
-	Controls: {
+	"webaudio-knob": {
 		// Master (BPM, Gain, Octave)
-		Master: {
-			BPM: {
-				top: "Change the global BPM",
-				bottom: "This will change the tempo of the arpeggiators"
-			},
-			Gain: {
-				top: "Change the master gain",
-				bottom: "This will change the overall volume of the synth"
-			},
-			Octave: {
-				top: "Change the global octave modifier",
-				bottom: "This will change the octave of all oscillators"
-			}
+		master_bpm: {
+			top: "Change the global BPM",
+			bottom: "This will change the tempo of the arpeggiators"
 		},
+		master_gain: {
+			top: "Change the master gain",
+			bottom: "This will change the overall volume of the synth"
+		},
+		// -- Osc A -- //
 		// FM (Voices, Spread, FM, Depth, Shape)
-		FM: {
-			Voices: {
-				top: "Change the number of voices",
-				bottom: "This will change the number of voices generated"
-			},
-			Spread: {
-				top: "Change the spread of the voices",
-				bottom: "This will offset the pitch of each voice (in cents)"
-			},
-			FM: {
-				top: "Change the FM modulator frequency",
-				bottom: "This will change the frequency of the FM modulator"
-			},
-			Depth: {
-				top: "Change the FM modulator depth",
-				bottom: "This will change the amplitude of Frequency Modulation"
-			},
-			Shape: {
-				top: "Change the FM modulator shape",
-				bottom: "This will change the shape of the FM modulator"
-			}
+		voices: {
+			top: "Change the number of voices",
+			bottom: "This will change the number of voices generated"
+		},
+		spread: {
+			top: "Change the spread of the voices",
+			bottom: "This will offset the pitch of each voice (in cents)"
+		},
+		fm: {
+			top: "Change the FM modulator frequency",
+			bottom: "This will change the frequency of the FM modulator"
+		},
+		fm_depth: {
+			top: "Change the FM modulator depth",
+			bottom: "This will change the amplitude of Frequency Modulation"
+		},
+		fm_shape: {
+			top: "Change the FM modulator shape",
+			bottom: "This will change the shape of the FM modulator"
+		},
+		// AM (AM, Shape)
+		am: {
+			top: "Change the AM modulator frequency",
+			bottom: "This will change the frequency of the AM modulator"
+		},
+		am_shape: {
+			top: "Change the AM modulator shape",
+			bottom: "This will change the shape of the AM modulator"
 		},
 		// ADSR (Attack, Decay, Sustain, Release)
-		ADSR: {
-			Attack: {
-				top: "Change the attack time",
-				bottom: "This will change the time it takes for the envelope to reach its peak"
-			},
-			Decay: {
-				top: "Change the decay time",
-				bottom: "This will change the time it takes for the envelope to reach its sustain level"
-			},
-			Sustain: {
-				top: "Change the sustain level",
-				bottom: "This will change the level the envelope will sustain at"
-			},
-			Release: {
-				top: "Change the release time",
-				bottom: "This will change the time it takes for the envelope to return to silence"
-			}
+		attack: {
+			top: "Change the attack time",
+			bottom: "This will change the time it takes for the envelope to reach its peak"
 		},
-		// Oscillator (Octave, Detune, Volume, Shape)
-		Oscillator: {
-			Octave: {
-				top: "Change the octave offset",
-				bottom: "This offsets the pitch of the oscillator, in octaves"
-			},
-			Detune: {
-				top: "Change the semitone offset",
-				bottom: "This offsets the pitch of the oscillator, in semitones"
-			},
-			Volume: {
-				top: "Change the volume",
-				bottom: "This changes the volume of the oscillator"
-			},
-			Shape: {
-				top: "Change the shape",
-				bottom: "This changes the shape of the oscillator"
-			}
+		decay: {
+			top: "Change the decay time",
+			bottom: "This will change the time it takes for the envelope to reach its sustain level"
+		},
+		sustain: {
+			top: "Change the sustain level",
+			bottom: "This will change the level the envelope will sustain at"
+		},
+		release: {
+			top: "Change the release time",
+			bottom: "This will change the time it takes for the envelope to return to silence"
+		},
+		// Main (Octave, Detune, Volume, Shape)
+		octave: {
+			top: "Change the octave offset",
+			bottom: "This offsets the pitch of the oscillator, in octaves"
+		},
+		semi: {
+			top: "Change the semitone offset",
+			bottom: "This offsets the pitch of the oscillator, in semitones"
+		},
+		volume: {
+			top: "Change the volume",
+			bottom: "This changes the volume of the oscillator"
 		},
 		// Filter (Cutoff, Q/Gain, Rolloff, Type)
-		Filter: {
-			Cutoff: {
-				top: "Change the filter cutoff frequency",
-				bottom: "This changes the cutoff frequency of the filter"
-			},
-			Q: {
-				top: "Change the filter Q (Resonance)",
-				bottom: "This changes the resonance of the filter"
-			},
-			Rolloff: {
-				top: "Change the filter rolloff",
-				bottom: "This changes the decibel rolloff of the filter curve"
-			},
-			Type: {
-				top: "Change the filter type",
-				bottom: "Choose between lowpass, highpass, bandpass, allpass, notch, lowshelf, and highshelf"
-			}
+		filter_cutoff: {
+			top: "Change the filter cutoff frequency",
+			bottom: "This changes the cutoff frequency of the filter"
+		},
+		// TODO: Change this if using shelf filters
+		filter_resonance: {
+			top: "Change the filter Q (Resonance)",
+			bottom: "This changes the resonance of the filter"
 		},
 		// LFO (Rate, Min, Max, Shape)
-		LFO: {
-			Select: {
-				top: "Select the LFO modulation target",
-				bottom: "Choose between filter frequency and oscillator volume"
-			},
-			Rate: {
-				top: "Change the LFO rate",
-				bottom: "This changes the rate of the LFO"
-			},
-			Min: {
-				top: "Change the LFO minimum value",
-				bottom: "This changes the minimum value of the LFO"
-			},
-			Max: {
-				top: "Change the LFO maximum value",
-				bottom: "This changes the maximum value of the LFO"
-			},
-			Shape: {
-				top: "Change the LFO shape",
-				bottom: "This changes the shape of the LFO"
-			}
+		lfo_rate: {
+			top: "Change the LFO rate",
+			bottom: "This changes the rate of the LFO"
 		},
-		// FX Distortion (Intensity, Oversample, Mix)
-		FX_DISTORTION: {
-			Intensity: {
-				top: "Change the distortion intensity",
-				bottom: "This changes the intensity of the distortion"
-			},
-			Oversample: {
-				top: "Change the distortion oversample",
-				bottom: "This changes the oversampling of the distortion algorithm"
-			},
-			Mix: {
-				top: "Change the distortion mix",
-				bottom: "This changes the wet level of the distortion effect"
-			}
+		lfo_min: {
+			top: "Change the LFO minimum value",
+			bottom: "This changes the minimum value of the LFO"
 		},
-		// FX Chebyshev (Order, Mix)
-		FX_CHEBYSHEV: {
-			Order: {
-				top: "Change the Chebyshev distortion order",
-				bottom: "This changes the order of the Chebyshev distortion algorithm"
-			},
-			Mix: {
-				top: "Change the Chebyshev distortion mix",
-				bottom: "This changes the wet level of the Chebyshev distortion effect"
-			}
+		lfo_max: {
+			top: "Change the LFO maximum value",
+			bottom: "This changes the maximum value of the LFO"
 		},
-		// FX Phaser (Frequency, Octaves, Q, Mix)
-		FX_PHASER: {
-			Frequency: {
-				top: "Change the phaser frequency",
-				bottom: "This changes the frequency of the phaser"
-			},
-			Octaves: {
-				top: "Change the phaser octaves",
-				bottom: "This changes the number of octaves of the phaser"
-			},
-			Q: {
-				top: "Change the phaser Q",
-				bottom: "This changes the Q of the phaser"
-			},
-			Mix: {
-				top: "Change the phaser mix",
-				bottom: "This changes the wet level of the phaser effect"
-			}
+		// FX (Param 1, Param 2, Param 3, Param 4)
+		// TODO: Swap these out depending on the selected FX
+		fx_param_1: {
+			top: "",
+			bottom: ""
 		},
-		// FX Tremolo (Frequency, Depth, Spread, Mix)
-		FX_TREMOLO: {
-			Frequency: {
-				top: "Change the tremolo frequency",
-				bottom: "This changes the frequency of the tremolo"
-			},
-			Depth: {
-				top: "Change the tremolo depth",
-				bottom: "This changes the depth of the tremolo"
-			},
-			Spread: {
-				top: "Change the tremolo spread",
-				bottom: "This changes the spread of the tremolo"
-			},
-			Mix: {
-				top: "Change the tremolo mix",
-				bottom: "This changes the wet level of the tremolo effect"
-			}
+		fx_param_2: {
+			top: "",
+			bottom: ""
 		},
-		// FX Vibrato (Frequency, Depth, Type, Mix)
-		FX_VIBRATO: {
-			Frequency: {
-				top: "Change the vibrato frequency",
-				bottom: "This changes the frequency of the vibrato"
-			},
-			Depth: {
-				top: "Change the vibrato depth",
-				bottom: "This changes the depth of the vibrato"
-			},
-			Type: {
-				top: "Change the vibrato type",
-				bottom: "Choose between different oscillator shapes"
-			},
-			Mix: {
-				top: "Change the vibrato mix",
-				bottom: "This changes the wet level of the vibrato effect"
-			}
+		fx_param_3: {
+			top: "",
+			bottom: ""
 		},
-		// FX Delay (Time, Feedback, Mix)
-		FX_DELAY: {
-			Time: {
-				top: "Change the delay time",
-				bottom: "This changes the time of the delay"
-			},
-			Feedback: {
-				top: "Change the delay feedback",
-				bottom: "This changes the feedback of the delay"
-			},
-			Mix: {
-				top: "Change the delay mix",
-				bottom: "This changes the wet level of the delay effect"
-			}
+		fx_param_4: {
+			top: "",
+			bottom: ""
+		}
+	},
+	"webaudio-slider": {
+		shape: {
+			top: "Change the shape",
+			bottom: "This changes the shape of the oscillator"
 		},
-		// FX Reverb (Decay, Pre-Delay, Mix)
-		FX_REVERB: {
-			Decay: {
-				top: "Change the reverb decay",
-				bottom: "This changes the decay of the reverb"
-			},
-			PreDelay: {
-				top: "Change the reverb pre-delay",
-				bottom: "This changes the pre-delay of the reverb"
-			},
-			Mix: {
-				top: "Change the reverb mix",
-				bottom: "This changes the wet level of the reverb effect"
-			}
+		filter_rolloff: {
+			top: "Change the filter rolloff",
+			bottom: "This changes the decibel rolloff of the filter curve"
 		},
-		// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
-		FX_PITCH_SHIFT: {
-			Pitch: {
-				top: "Change the pitch shift pitch",
-				bottom: "This changes the pitch of the pitch shift"
-			},
-			WindowSize: {
-				top: "Change the pitch shift window size",
-				bottom: "This changes the window size of the pitch shift"
-			},
-			Feedback: {
-				top: "Change the pitch shift feedback",
-				bottom: "This changes the feedback of the pitch shift"
-			},
-			Mix: {
-				top: "Change the pitch shift mix",
-				bottom: "This changes the wet level of the pitch shift effect"
-			}
+		filter_type: {
+			top: "Change the filter type",
+			bottom: "Choose between lowpass, highpass, bandpass, allpass, notch, lowshelf, and highshelf"
 		},
-		// FX Freq Shift (Frequency, Mix)
-		FX_FREQ_SHIFT: {
-			Frequency: {
-				top: "Change the frequency shift frequency",
-				bottom: "This changes the frequency of the frequency shift"
-			},
-			Mix: {
-				top: "Change the frequency shift mix",
-				bottom: "This changes the wet level of the frequency shift effect"
-			}
+		lfo_shape: {
+			top: "Change the LFO shape",
+			bottom: "This changes the shape of the LFO"
 		},
-		// ARP (Pattern, Speed)
-		ARP: {
-			Pattern: {
-				top: "Change the arp pattern",
-				bottom: "This changes the pattern of the arp"
-			},
-			Speed: {
-				top: "Change the arp speed",
-				bottom: "This changes the speed of the arp"
-			}
+		arp_pattern: {
+			top: "Change the arp pattern",
+			bottom: "This changes the pattern of the arp"
+		},
+		arp_speed: {
+			top: "Change the arp speed",
+			bottom: "This changes the speed of the arp"
+		},
+		master_octave: {
+			top: "Change the global octave modifier",
+			bottom: "This will change the octave of all oscillators"
+		},
+	},
+	select: {
+		lfo_selector: {
+			top: "Select the LFO modulation target",
+			bottom: "Choose between filter frequency and oscillator volume"
+		},
+		fx_selector: {
+			top: "Select an effect",
+			bottom: "Choose from a range of different effects!"
+		}
+	},
+	canvas: {
+		oscilloscope_a: {
+			top: "Oscilloscope A",
+			bottom: "This visualises the waveform of oscillator A!"
+		},
+		oscilloscope_b: {
+			top: "Oscilloscope B",
+			bottom: "This visualises the waveform of oscillator B!"
+		},
+		oscilloscope_c: {
+			top: "Oscilloscope C",
+			bottom: "This visualises the waveform of oscillator C!"
+		},
+		oscilloscope_lfo: {
+			top: "LFO Oscilloscope",
+			bottom: "This visualises the waveform of the LFO!"
+		},
+		oscilloscope_master: {
+			top: "Master Oscilloscope",
+			bottom: "This visualises the waveform of the master output!"
+		}
+	},
+	"webaudio-keyboard": {
+		keyboard: {
+			top: "GUI Keyboard",
+			bottom: "Click on the keys to play them, or use your keyboard!"
+		}
+	}
+}
+
+let fxTooltips = {
+	// FX Distortion (Intensity, Oversample, Mix)
+	FX_DISTORTION: {
+		Intensity: {
+			top: "Change the distortion intensity",
+			bottom: "This changes the intensity of the distortion"
+		},
+		Oversample: {
+			top: "Change the distortion oversample",
+			bottom: "This changes the oversampling of the distortion algorithm"
+		},
+		Mix: {
+			top: "Change the distortion mix",
+			bottom: "This changes the wet level of the distortion effect"
+		}
+	},
+	// FX Chebyshev (Order, Mix)
+	FX_CHEBYSHEV: {
+		Order: {
+			top: "Change the Chebyshev distortion order",
+			bottom: "This changes the order of the Chebyshev distortion algorithm"
+		},
+		Mix: {
+			top: "Change the Chebyshev distortion mix",
+			bottom: "This changes the wet level of the Chebyshev distortion effect"
+		}
+	},
+	// FX Phaser (Frequency, Octaves, Q, Mix)
+	FX_PHASER: {
+		Frequency: {
+			top: "Change the phaser frequency",
+			bottom: "This changes the frequency of the phaser"
+		},
+		Octaves: {
+			top: "Change the phaser octaves",
+			bottom: "This changes the number of octaves of the phaser"
+		},
+		Q: {
+			top: "Change the phaser Q",
+			bottom: "This changes the Q of the phaser"
+		},
+		Mix: {
+			top: "Change the phaser mix",
+			bottom: "This changes the wet level of the phaser effect"
+		}
+	},
+	// FX Tremolo (Frequency, Depth, Spread, Mix)
+	FX_TREMOLO: {
+		Frequency: {
+			top: "Change the tremolo frequency",
+			bottom: "This changes the frequency of the tremolo"
+		},
+		Depth: {
+			top: "Change the tremolo depth",
+			bottom: "This changes the depth of the tremolo"
+		},
+		Spread: {
+			top: "Change the tremolo spread",
+			bottom: "This changes the spread of the tremolo"
+		},
+		Mix: {
+			top: "Change the tremolo mix",
+			bottom: "This changes the wet level of the tremolo effect"
+		}
+	},
+	// FX Vibrato (Frequency, Depth, Type, Mix)
+	FX_VIBRATO: {
+		Frequency: {
+			top: "Change the vibrato frequency",
+			bottom: "This changes the frequency of the vibrato"
+		},
+		Depth: {
+			top: "Change the vibrato depth",
+			bottom: "This changes the depth of the vibrato"
+		},
+		Type: {
+			top: "Change the vibrato type",
+			bottom: "Choose between different oscillator shapes"
+		},
+		Mix: {
+			top: "Change the vibrato mix",
+			bottom: "This changes the wet level of the vibrato effect"
+		}
+	},
+	// FX Delay (Time, Feedback, Mix)
+	FX_DELAY: {
+		Time: {
+			top: "Change the delay time",
+			bottom: "This changes the time of the delay"
+		},
+		Feedback: {
+			top: "Change the delay feedback",
+			bottom: "This changes the feedback of the delay"
+		},
+		Mix: {
+			top: "Change the delay mix",
+			bottom: "This changes the wet level of the delay effect"
+		}
+	},
+	// FX Reverb (Decay, Pre-Delay, Mix)
+	FX_REVERB: {
+		Decay: {
+			top: "Change the reverb decay",
+			bottom: "This changes the decay of the reverb"
+		},
+		PreDelay: {
+			top: "Change the reverb pre-delay",
+			bottom: "This changes the pre-delay of the reverb"
+		},
+		Mix: {
+			top: "Change the reverb mix",
+			bottom: "This changes the wet level of the reverb effect"
+		}
+	},
+	// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
+	FX_PITCH_SHIFT: {
+		Pitch: {
+			top: "Change the pitch shift pitch",
+			bottom: "This changes the pitch of the pitch shift"
+		},
+		WindowSize: {
+			top: "Change the pitch shift window size",
+			bottom: "This changes the window size of the pitch shift"
+		},
+		Feedback: {
+			top: "Change the pitch shift feedback",
+			bottom: "This changes the feedback of the pitch shift"
+		},
+		Mix: {
+			top: "Change the pitch shift mix",
+			bottom: "This changes the wet level of the pitch shift effect"
+		}
+	},
+	// FX Freq Shift (Frequency, Mix)
+	FX_FREQ_SHIFT: {
+		Frequency: {
+			top: "Change the frequency shift frequency",
+			bottom: "This changes the frequency of the frequency shift"
+		},
+		Mix: {
+			top: "Change the frequency shift mix",
+			bottom: "This changes the wet level of the frequency shift effect"
 		}
 	}
 }

--- a/src/synth.js
+++ b/src/synth.js
@@ -3352,38 +3352,342 @@ consentButton.addEventListener("click", function () {
 
 // Buttons (Settings, Presets, Random)
 
-// Switches (Groups, Arpeggiators, Sends, Record)
-
-// Controls - Master (BPM, Gain, Octave)
-
-// Controls - FM (Voices, Spread, FM, Depth, Shape)
-
-// Controls - ADSR (Attack, Decay, Sustain, Release)
-
-// Controls - Oscillator (Octave, Detune, Volume, Shape)
-
-// Controls - Filter (Cutoff, Q/Gain, Rolloff, Type)
-
-// Controls - LFO (Rate, Min, Max, Shape)
-
-// Selects - LFO (Filter Frequency, Oscillator Volume)
-
-// Controls - FX Distortion (Intensity, Oversample, Mix)
-
-// Controls - FX Chebyshev (Order, Mix)
-
-// Controls - FX Phaser (Frequency, Octaves, Q, Mix)
-
-// Controls - FX Tremolo (Frequency, Depth, Spread, Mix)
-
-// Controls - FX Vibrato (Frequency, Depth, Type, Mix)
-
-// Controls - FX Delay (Time, Feedback, Mix)
-
-// Controls - FX Reverb (Decay, Pre-Delay, Mix)
-
-// Controls - FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
-
-// Controls - FX Freq Shift (Frequency, Mix)
-
-// Controls - ARP (Pattern, Speed)
+let tooltips = {
+	Defaults: {
+		top: "Tooltips go here!",
+		bottom: "Hover over something to see what it does!"
+	},
+	// Buttons (Settings, Presets, Random)
+	Buttons: {
+		Settings: {
+			top: "Change synth settings",
+			bottom: "Return home, or change the theme!"
+		},
+		Presets: {
+			top: "Open the preset menu",
+			bottom: "Load a preset, or save your own!"
+		},
+		Random: {
+			top: "Randomise the synth settings",
+			bottom: "Careful! This will overwrite your current settings!"
+		}
+	},
+	// Switches (Groups, Arpeggiators, Sends, Record)
+	Switches: {
+		A: {
+			top: "Toggle oscillator A",
+			bottom: "This will turn the oscillator on or off"
+		},
+		B: {
+			top: "Toggle oscillator B",
+			bottom: "This will turn the oscillator on or off"
+		},
+		C: {
+			top: "Toggle oscillator C",
+			bottom: "This will turn the oscillator on or off"
+		},
+		Filter: {
+			top: "Toggle filter",
+			bottom: "This will turn the filter on or off"
+		},
+		FilterSend_A: {
+			top: "Toggle filter for oscillator A",
+			bottom: "This will turn the filter on or off only for oscillator A"
+		},
+		FilterSend_B: {
+			top: "Toggle filter for oscillator B",
+			bottom: "This will turn the filter on or off only for oscillator B"
+		},
+		FilterSend_C: {
+			top: "Toggle filter for oscillator C",
+			bottom: "This will turn the filter on or off only for oscillator C"
+		},
+		LFO: {
+			top: "Toggle LFO",
+			bottom: "This will turn the LFO on or off"
+		},
+		FX: {
+			top: "Toggle FX",
+			bottom: "This will turn the FX on or off"
+		},
+		Arpeggiator: {
+			top: "Toggle arpeggiator (for this oscillator)",
+			bottom: "This will turn the arpeggiator on or off"
+		}
+	},
+	// Controls
+	Controls: {
+		// Master (BPM, Gain, Octave)
+		Master: {
+			BPM: {
+				top: "Change the global BPM",
+				bottom: "This will change the tempo of the arpeggiators"
+			},
+			Gain: {
+				top: "Change the master gain",
+				bottom: "This will change the overall volume of the synth"
+			},
+			Octave: {
+				top: "Change the global octave modifier",
+				bottom: "This will change the octave of all oscillators"
+			}
+		},
+		// FM (Voices, Spread, FM, Depth, Shape)
+		FM: {
+			Voices: {
+				top: "Change the number of voices",
+				bottom: "This will change the number of voices generated"
+			},
+			Spread: {
+				top: "Change the spread of the voices",
+				bottom: "This will offset the pitch of each voice (in cents)"
+			},
+			FM: {
+				top: "Change the FM modulator frequency",
+				bottom: "This will change the frequency of the FM modulator"
+			},
+			Depth: {
+				top: "Change the FM modulator depth",
+				bottom: "This will change the amplitude of Frequency Modulation"
+			},
+			Shape: {
+				top: "Change the FM modulator shape",
+				bottom: "This will change the shape of the FM modulator"
+			}
+		},
+		// ADSR (Attack, Decay, Sustain, Release)
+		ADSR: {
+			Attack: {
+				top: "Change the attack time",
+				bottom: "This will change the time it takes for the envelope to reach its peak"
+			},
+			Decay: {
+				top: "Change the decay time",
+				bottom: "This will change the time it takes for the envelope to reach its sustain level"
+			},
+			Sustain: {
+				top: "Change the sustain level",
+				bottom: "This will change the level the envelope will sustain at"
+			},
+			Release: {
+				top: "Change the release time",
+				bottom: "This will change the time it takes for the envelope to return to silence"
+			}
+		},
+		// Oscillator (Octave, Detune, Volume, Shape)
+		Oscillator: {
+			Octave: {
+				top: "Change the octave offset",
+				bottom: "This offsets the pitch of the oscillator, in octaves"
+			},
+			Detune: {
+				top: "Change the semitone offset",
+				bottom: "This offsets the pitch of the oscillator, in semitones"
+			},
+			Volume: {
+				top: "Change the volume",
+				bottom: "This changes the volume of the oscillator"
+			},
+			Shape: {
+				top: "Change the shape",
+				bottom: "This changes the shape of the oscillator"
+			}
+		},
+		// Filter (Cutoff, Q/Gain, Rolloff, Type)
+		Filter: {
+			Cutoff: {
+				top: "Change the filter cutoff frequency",
+				bottom: "This changes the cutoff frequency of the filter"
+			},
+			Q: {
+				top: "Change the filter Q (Resonance)",
+				bottom: "This changes the resonance of the filter"
+			},
+			Rolloff: {
+				top: "Change the filter rolloff",
+				bottom: "This changes the decibel rolloff of the filter curve"
+			},
+			Type: {
+				top: "Change the filter type",
+				bottom: "Choose between lowpass, highpass, bandpass, allpass, notch, lowshelf, and highshelf"
+			}
+		},
+		// LFO (Rate, Min, Max, Shape)
+		LFO: {
+			Select: {
+				top: "Select the LFO modulation target",
+				bottom: "Choose between filter frequency and oscillator volume"
+			},
+			Rate: {
+				top: "Change the LFO rate",
+				bottom: "This changes the rate of the LFO"
+			},
+			Min: {
+				top: "Change the LFO minimum value",
+				bottom: "This changes the minimum value of the LFO"
+			},
+			Max: {
+				top: "Change the LFO maximum value",
+				bottom: "This changes the maximum value of the LFO"
+			},
+			Shape: {
+				top: "Change the LFO shape",
+				bottom: "This changes the shape of the LFO"
+			}
+		},
+		// FX Distortion (Intensity, Oversample, Mix)
+		FX_DISTORTION: {
+			Intensity: {
+				top: "Change the distortion intensity",
+				bottom: "This changes the intensity of the distortion"
+			},
+			Oversample: {
+				top: "Change the distortion oversample",
+				bottom: "This changes the oversampling of the distortion algorithm"
+			},
+			Mix: {
+				top: "Change the distortion mix",
+				bottom: "This changes the wet level of the distortion effect"
+			}
+		},
+		// FX Chebyshev (Order, Mix)
+		FX_CHEBYSHEV: {
+			Order: {
+				top: "Change the Chebyshev distortion order",
+				bottom: "This changes the order of the Chebyshev distortion algorithm"
+			},
+			Mix: {
+				top: "Change the Chebyshev distortion mix",
+				bottom: "This changes the wet level of the Chebyshev distortion effect"
+			}
+		},
+		// FX Phaser (Frequency, Octaves, Q, Mix)
+		FX_PHASER: {
+			Frequency: {
+				top: "Change the phaser frequency",
+				bottom: "This changes the frequency of the phaser"
+			},
+			Octaves: {
+				top: "Change the phaser octaves",
+				bottom: "This changes the number of octaves of the phaser"
+			},
+			Q: {
+				top: "Change the phaser Q",
+				bottom: "This changes the Q of the phaser"
+			},
+			Mix: {
+				top: "Change the phaser mix",
+				bottom: "This changes the wet level of the phaser effect"
+			}
+		},
+		// FX Tremolo (Frequency, Depth, Spread, Mix)
+		FX_TREMOLO: {
+			Frequency: {
+				top: "Change the tremolo frequency",
+				bottom: "This changes the frequency of the tremolo"
+			},
+			Depth: {
+				top: "Change the tremolo depth",
+				bottom: "This changes the depth of the tremolo"
+			},
+			Spread: {
+				top: "Change the tremolo spread",
+				bottom: "This changes the spread of the tremolo"
+			},
+			Mix: {
+				top: "Change the tremolo mix",
+				bottom: "This changes the wet level of the tremolo effect"
+			}
+		},
+		// FX Vibrato (Frequency, Depth, Type, Mix)
+		FX_VIBRATO: {
+			Frequency: {
+				top: "Change the vibrato frequency",
+				bottom: "This changes the frequency of the vibrato"
+			},
+			Depth: {
+				top: "Change the vibrato depth",
+				bottom: "This changes the depth of the vibrato"
+			},
+			Type: {
+				top: "Change the vibrato type",
+				bottom: "Choose between different oscillator shapes"
+			},
+			Mix: {
+				top: "Change the vibrato mix",
+				bottom: "This changes the wet level of the vibrato effect"
+			}
+		},
+		// FX Delay (Time, Feedback, Mix)
+		FX_DELAY: {
+			Time: {
+				top: "Change the delay time",
+				bottom: "This changes the time of the delay"
+			},
+			Feedback: {
+				top: "Change the delay feedback",
+				bottom: "This changes the feedback of the delay"
+			},
+			Mix: {
+				top: "Change the delay mix",
+				bottom: "This changes the wet level of the delay effect"
+			}
+		},
+		// FX Reverb (Decay, Pre-Delay, Mix)
+		FX_REVERB: {
+			Decay: {
+				top: "Change the reverb decay",
+				bottom: "This changes the decay of the reverb"
+			},
+			PreDelay: {
+				top: "Change the reverb pre-delay",
+				bottom: "This changes the pre-delay of the reverb"
+			},
+			Mix: {
+				top: "Change the reverb mix",
+				bottom: "This changes the wet level of the reverb effect"
+			}
+		},
+		// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
+		FX_PITCH_SHIFT: {
+			Pitch: {
+				top: "Change the pitch shift pitch",
+				bottom: "This changes the pitch of the pitch shift"
+			},
+			WindowSize: {
+				top: "Change the pitch shift window size",
+				bottom: "This changes the window size of the pitch shift"
+			},
+			Feedback: {
+				top: "Change the pitch shift feedback",
+				bottom: "This changes the feedback of the pitch shift"
+			},
+			Mix: {
+				top: "Change the pitch shift mix",
+				bottom: "This changes the wet level of the pitch shift effect"
+			}
+		},
+		// FX Freq Shift (Frequency, Mix)
+		FX_FREQ_SHIFT: {
+			Frequency: {
+				top: "Change the frequency shift frequency",
+				bottom: "This changes the frequency of the frequency shift"
+			},
+			Mix: {
+				top: "Change the frequency shift mix",
+				bottom: "This changes the wet level of the frequency shift effect"
+			}
+		},
+		// ARP (Pattern, Speed)
+		ARP: {
+			Pattern: {
+				top: "Change the arp pattern",
+				bottom: "This changes the pattern of the arp"
+			},
+			Speed: {
+				top: "Change the arp speed",
+				bottom: "This changes the speed of the arp"
+			}
+		}
+	}
+}

--- a/src/synth.js
+++ b/src/synth.js
@@ -162,7 +162,7 @@ let PRESET = {
 // TODO: Add each FX type to the PRESET object
 
 // -- MIN/MAX DATA (to be used for randomization) -- //
-
+// TODO: Reference Tone.js documentation to ensure correct min/max values
 let MIN_MAX = {
 	MASTER: {
 		gain: [0, 2]
@@ -843,18 +843,16 @@ function updateFilterKnob(target, enable, min, max, step, value, label) {
 	}
 }
 function filterGroupUpdate(target) {
+	// TODO: Fix bugs!!!
 	// If filter type is lowshelf or highshelf...
 	if (target === 5 || target === 6) {
-		// ...change the filter Q knob to gain knob
+		// ...change the filter resonance knob to gain knob
 		updateFilterKnob("filter_resonance", 1, 0, 24, 0.1, PRESET.FILTER.gain.toFixed(1), "Gain")
-		tooltips["webaudio-knob"].filter_resonance.top = "Change the filter gain"
-		tooltips["webaudio-knob"].filter_resonance.bottom = "This changes the gain of the shelf filter"
-	// Else if filter type is not lowshelf or highshelf...
+		tooltips["webaudio-knob"].filter_resonance = dynamicTooltips.FilterGain
 	} else {
-		// ...change the filter gain knob to Q knob
+		// ...change the filter gain knob to resonace knob
 		updateFilterKnob("filter_resonance", 1, 1, 10, 0.1, PRESET.FILTER.Q, "Q")
-		tooltips["webaudio-knob"].filter_resonance.top = "Change the filter Q"
-		tooltips["webaudio-knob"].filter_resonance.bottom = "This changes the resonance of the filter, be careful!"
+		tooltips["webaudio-knob"].filter_resonance = dynamicTooltips.FilterResonance
 	}
 }
 
@@ -941,6 +939,7 @@ function updateFxKnob(target, enable, min, max, step, value, label, conv) {
 }
 
 function fxGroupUpdate(switchTarget){
+	// TODO: Start using MIN_MAX values instead of hardcoding them
 	switch (switchTarget) {
 		case "Distortion":
 			PRESET.FX.type = "Distortion"
@@ -957,9 +956,9 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Distortion"]["Intensity"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Distortion"]["Oversample"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Distortion"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Distortion"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Distortion"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Distortion"]["fx_param3"]
 			break;
 		case "Chebyshev":
 			PRESET.FX.type = "Chebyshev"
@@ -970,8 +969,8 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 0)
 			updateFxKnob(4, 0)
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Chebyshev"]["Order"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Chebyshev"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Chebyshev"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Chebyshev"]["fx_param2"]
 			break;
 		case "Phaser":
 			PRESET.FX.type = "Phaser"
@@ -982,24 +981,24 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 100, 0.1, 1, "Q")
 			updateFxKnob(4, 1, 0, 1, 0.1, 1, "Mix")
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Phaser"]["Frequency"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Phaser"]["Octaves"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Phaser"]["Q"]
-			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Phaser"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Phaser"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Phaser"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Phaser"]["fx_param3"]
+			tooltips["webaudio-knob"].fx_param4 = dynamicTooltips["Phaser"]["fx_param4"]
 			break;
 		case "Tremolo":
 			PRESET.FX.type = "Tremolo"
 			SELECTED_FX = FX_TREMOLO
 
-			updateFxKnob(1, 1, 0, 20000, 0.1, 0, "Frequency")
+			updateFxKnob(1, 1, 0, 64, 0.1, 0, "Frequency")
 			updateFxKnob(2, 1, 0, 1, 0.01, 0, "Depth")
-			updateFxKnob(3, 1, 0, 100, 0.01, 0, "Spread")
+			updateFxKnob(3, 1, 0, 180, 1, 0, "Spread")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Tremolo"]["Frequency"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Tremolo"]["Depth"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Tremolo"]["Spread"]
-			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Tremolo"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Tremolo"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Tremolo"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Tremolo"]["fx_param3"]
+			tooltips["webaudio-knob"].fx_param4 = dynamicTooltips["Tremolo"]["fx_param4"]
 			break;
 		case "Vibrato":
 			PRESET.FX.type = "Vibrato"
@@ -1010,10 +1009,10 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 3, 1, 0, "Type", "['sine','triangle','sawtooth','square'][x]")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Vibrato"]["Frequency"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Vibrato"]["Depth"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Vibrato"]["Type"]
-			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Vibrato"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Vibrato"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Vibrato"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Vibrato"]["fx_param3"]
+			tooltips["webaudio-knob"].fx_param4 = dynamicTooltips["Vibrato"]["fx_param4"]
 			break;
 		case "Delay":
 			PRESET.FX.type = "Delay"
@@ -1024,9 +1023,9 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Delay"]["Time"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Delay"]["Feedback"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Delay"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Delay"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Delay"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Delay"]["fx_param3"]
 			break;
 		case "Reverb":
 			PRESET.FX.type = "Reverb"
@@ -1037,9 +1036,9 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Reverb"]["Decay"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Reverb"]["Pre-delay"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Reverb"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["Reverb"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["Reverb"]["Pre-delay"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["Reverb"]["fx_param3"]
 			break;
 		case "PitchShift":
 			PRESET.FX.type = "PitchShift"
@@ -1050,10 +1049,10 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 1, 0, 1, 0.01, 0.5, "Feedback")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["PitchShift"]["Pitch"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["PitchShift"]["Size"]
-			tooltips["webaudio-knob"].fx_param3 = fxTooltips["PitchShift"]["Feedback"]
-			tooltips["webaudio-knob"].fx_param4 = fxTooltips["PitchShift"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["PitchShift"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["PitchShift"]["fx_param2"]
+			tooltips["webaudio-knob"].fx_param3 = dynamicTooltips["PitchShift"]["fx_param3"]
+			tooltips["webaudio-knob"].fx_param4 = dynamicTooltips["PitchShift"]["fx_param4"]
 			break;
 		case "FreqShift":
 			PRESET.FX.type = "FreqShift"
@@ -1064,8 +1063,8 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(3, 0)
 			updateFxKnob(4, 0)
 
-			tooltips["webaudio-knob"].fx_param1 = fxTooltips["FreqShift"]["Frequency"]
-			tooltips["webaudio-knob"].fx_param2 = fxTooltips["FreqShift"]["Mix"]
+			tooltips["webaudio-knob"].fx_param1 = dynamicTooltips["FreqShift"]["fx_param1"]
+			tooltips["webaudio-knob"].fx_param2 = dynamicTooltips["FreqShift"]["fx_param2"]
 			break;
 		default:
 			console.log("Switch default: Nothing set for this case!")
@@ -3431,63 +3430,246 @@ for (let i = 0; i < tooltip_elements.length; i++) {
 	})
 }
 
+let dynamicTooltips = {
+	// Filter (Resonance/Gain)
+	FilterResonance: {
+		top: "Filter resonance",
+		bottom: "This emphasises frequencies near the cutoff, be careful!"
+	},
+	FilterGain: {
+		top: "Filter gain",
+		bottom: "This sets the amplitude of the cutoff frequencies!"
+	},
+	// FX Distortion (Intensity, Oversample, Mix)
+	Distortion: {
+		fx_param1: {
+			top: "Distortion intensity",
+			bottom: "The amount of distortion applied to the signal!"
+		},
+		fx_param2: {
+			top: "Distortion oversample",
+			bottom: "Higher quality distortion, at the cost of performance!"
+		},
+		fx_param3: {
+			top: "Distortion mix",
+			bottom: "The ratio between the dry and wet signals!"
+		},
+		fx_param4: {
+			top: "",
+			bottom: ""
+		}
+	},
+	// FX Chebyshev (Order, Mix)
+	Chebyshev: {
+		fx_param1: {
+			top: "Chebyshev order",
+			bottom: "The order of the Chebyshev polynomial used for distortion!"
+		},
+		fx_param2: {
+			top: "Chebyshev mix",
+			bottom: "The ratio between the dry and wet signals!"
+		},
+		fx_param3: {
+			top: "",
+			bottom: ""
+		},
+		fx_param4: {
+			top: "",
+			bottom: ""
+		}
+	},
+	// FX Phaser (Frequency, Octaves, Q, Mix)
+	Phaser: {
+		fx_param1: {
+			top: "Phaser frequency",
+			bottom: "The speed of the phasing effect!"
+		},
+		fx_param2: {
+			top: "Phaser octaves",
+			bottom: "The octaves of the effect!"
+		},
+		fx_param3: {
+			top: "Phaser Q",
+			bottom: "The quality factor of the filters!"
+		},
+		fx_param4: {
+			top: "Phaser mix",
+			bottom: "The ratio between the dry and wet signals!"
+		}
+	},
+	// FX Tremolo (Frequency, Depth, Spread, Mix)
+	Tremolo: {
+		fx_param1: {
+			top: "Tremolo frequency",
+			bottom: "The speed of the tremolo effect!"
+		},
+		fx_param2: {
+			top: "Tremolo depth",
+			bottom: "The depth of the tremolo effect!"
+		},
+		fx_param3: {
+			top: "Tremolo spread",
+			bottom: "The amount of stereo spread!"
+		},
+		fx_param4: {
+			top: "Tremolo mix",
+			bottom: "The ratio between the dry and wet signals!"
+		}
+	},
+	// FX Vibrato (Frequency, Depth, Type, Mix)
+	Vibrato: {
+		fx_param1: {
+			top: "Vibrato frequency",
+			bottom: "The speed of the vibrato effect!"
+		},
+		fx_param2: {
+			top: "Vibrato depth",
+			bottom: "The depth of the vibrato effect!"
+		},
+		fx_param3: {
+			top: "Vibrato type",
+			bottom: "The type of oscillator used for the vibrato effect!"
+		},
+		fx_param4: {
+			top: "Vibrato mix",
+			bottom: "The ratio between the dry and wet signals!"
+		}
+	},
+	// FX Delay (Time, Feedback, Mix)
+	Delay: {
+		fx_param1: {
+			top: "Delay time",
+			bottom: "The amount of time the incoming signal is delayed by!"
+		},
+		fx_param2: {
+			top: "Delay feedback",
+			bottom: "The amount of signal fed back into the delay!"
+		},
+		fx_param3: {
+			top: "Delay mix",
+			bottom: "The ratio between the dry and wet signals!"
+		},
+		fx_param4: {
+			top: "",
+			bottom: ""
+		}
+	},
+	// FX Reverb (Decay, Pre-Delay, Mix)
+	Reverb: {
+		fx_param1: {
+			top: "Reverb decay",
+			bottom: "The duration of the reverb effect!"
+		},
+		fx_param2: {
+			top: "Reverb pre-delay",
+			bottom: "The amount of time before the reverb is fully applied!"
+		},
+		fx_param3: {
+			top: "Reverb mix",
+			bottom: "The ratio between the dry and wet signals!"
+		},
+		fx_param4: {
+			top: "",
+			bottom: ""
+		}
+	},
+	// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
+	PitchShift: {
+		fx_param1: {
+			top: "Pitch shift pitch",
+			bottom: "The pitch offset in semitones!"
+		},
+		fx_param2: {
+			top: "Pitch shift window size",
+			bottom: "The sample length, high values result in strange artifacts!"
+		},
+		fx_param3: {
+			top: "Pitch shift feedback",
+			bottom: "The amount of signal fed back into the pitch shift!"
+		},
+		fx_param4: {
+			top: "Pitch shift mix",
+			bottom: "The ratio between the dry and wet signals!"
+		}
+	},
+	// FX Frequency Shift (Frequency, Mix)
+	FreqShift: {
+		fx_param1: {
+			top: "Frequency shift frequency",
+			bottom: "The ring modulator carrier frequency!"
+		},
+		fx_param2: {
+			top: "Frequency shift mix",
+			bottom: "The ratio between the dry and wet signals!"
+		},
+		fx_param3: {
+			top: "",
+			bottom: ""
+		},
+		fx_param4: {
+			top: "",
+			bottom: ""
+		}
+	}
+}
+
 let tooltips = {
 	defaults: {
-		top: "Tooltips go here :)",
-		bottom: "Hover over something to see what it does!"
+		top: "Tooltips go here!",
+		bottom: "Hover over something to see what it does &#128516;"
 	},
 	// Buttons (Settings, Presets, Random)
 	button: {
 		settings_button: {
-			top: "Change synth settings",
+			top: "Open settings menu",
 			bottom: "Return home, or change the theme!"
 		},
 		presets_button: {
-			top: "Open the preset menu",
+			top: "Open preset menu",
 			bottom: "Load a preset, or save your own!"
 		},
 		random_preset_button: {
-			top: "Randomise the synth settings",
-			bottom: "Careful! This will overwrite your current settings!"
+			top: "Randomise synth settings",
+			bottom: "Careful! This can result in VERY loud sounds!"
 		}
 	},
 	p: {
 		osc_a_label: {
-			top: "Oscillator A",
+			top: "Oscillator A (FM)",
 			bottom: "Oscillators are the main sound generators in a synthesizer!"
 		},
 		arp_a_label: {
 			top: "Arpeggiator A",
-			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+			bottom: "Arpeggiators play held notes in a sequence!"
 		},
 		osc_b_label: {
-			top: "Oscillator B",
+			top: "Oscillator B (FM)",
 			bottom: "Oscillators are the main sound generators in a synthesizer!"
 		},
 		arp_b_label: {
 			top: "Arpeggiator B",
-			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+			bottom: "Arpeggiators play held notes in a sequence!"
 		},
 		osc_c_label: {
-			top: "Oscillator C",
+			top: "Oscillator C (AM)",
 			bottom: "Oscillators are the main sound generators in a synthesizer!"
 		},
 		arp_c_label: {
 			top: "Arpeggiator C",
-			bottom: "Arpeggiators play notes in a sequence! Try holding multiple keys!"
+			bottom: "Arpeggiators play held notes in a sequence!"
 		},
 		filter_label: {
 			top: "Filter",
-			bottom: "Filters shape the sound by cutting out certain frequencies!"
+			bottom: "Filters shape sound by cutting out certain frequencies!"
 		}
 	},
 	label: {
 		lfo_label: {
-			top: "LFO",
-			bottom: "LFOs (Low Frequency Oscillators) are used to automatically modulate parameters over time!"
+			top: "Low Frequency Oscillator",
+			bottom: "LFOs are used to automatically modulate parameters over time!"
 		},
 		fx_label: {
-			top: "FX",
+			top: "FX (Effects)",
 			bottom: "Choose from several effects to manipulate your sound with!"
 		},
 	},
@@ -3495,381 +3677,220 @@ let tooltips = {
 	"webaudio-switch": {
 		osc_a_switch: {
 			top: "Toggle Oscillator A",
-			bottom: "This will turn the oscillator on or off"
+			bottom: "Turn the oscillator on or off!"
 		},
 		arp_a_switch: {
 			top: "Toggle Arpeggiator A",
-			bottom: "This will turn the arpeggiator on or off"
+			bottom: "Turn the arpeggiator on or off!"
 		},
 		osc_b_switch: {
 			top: "Toggle Oscillator B",
-			bottom: "This will turn the oscillator on or off"
+			bottom: "Turn the oscillator on or off!"
 		},
 		arp_b_switch: {
 			top: "Toggle Arpeggiator B",
-			bottom: "This will turn the arpeggiator on or off"
+			bottom: "Turn the arpeggiator on or off!"
 		},
 		osc_c_switch: {
 			top: "Toggle Oscillator C",
-			bottom: "This will turn the oscillator on or off"
+			bottom: "Turn the oscillator on or off!"
 		},
 		arp_c_switch: {
 			top: "Toggle Arpeggiator C",
-			bottom: "This will turn the arpeggiator on or off"
+			bottom: "Turn the arpeggiator on or off!"
 		},
 		filter_switch: {
 			top: "Toggle Filter",
-			bottom: "This will turn the filter on or off"
+			bottom: "Turn the filter on or off!"
 		},
 		osc_a_filter_switch: {
-			top: "Toggle filter for oscillator A",
-			bottom: "This will turn the filter on or off only for oscillator A"
+			top: "Toggle Oscillator A Send",
+			bottom: "Turn the filter on or off for oscillator A!"
 		},
 		osc_b_filter_switch: {
-			top: "Toggle filter for oscillator B",
-			bottom: "This will turn the filter on or off only for oscillator B"
+			top: "Toggle Oscillator B Send",
+			bottom: "Turn the filter on or off for oscillator B!"
 		},
 		osc_c_filter_switch: {
-			top: "Toggle filter for oscillator C",
-			bottom: "This will turn the filter on or off only for oscillator C"
+			top: "Toggle Oscillator C Send",
+			bottom: "Turn the filter on or off for oscillator C!"
 		},
 		lfo_switch: {
 			top: "Toggle LFO",
-			bottom: "This will turn the LFO on or off"
+			bottom: "Turn the LFO on or off!"
 		},
 		fx_switch: {
 			top: "Toggle FX",
-			bottom: "This will turn the FX on or off"
+			bottom: "Turn the FX on or off!"
 		},
 		rec_switch: {
 			top: "Toggle recording",
-			bottom: "This will start or stop recording the synth output"
+			bottom: "Start or stop recording the synth output!"
 		}
 	},
 	// Controls
 	"webaudio-knob": {
 		// Master (BPM, Gain, Octave)
 		master_bpm: {
-			top: "Change the global BPM",
-			bottom: "This will change the tempo of the arpeggiators"
+			top: "Global BPM",
+			bottom: "The tempo of the arpeggiators!"
 		},
 		master_gain: {
-			top: "Change the master gain",
-			bottom: "This will change the overall volume of the synth"
+			top: "Master Gain",
+			bottom: "The overall volume of the synth!"
 		},
 		// -- Osc A -- //
 		// FM (Voices, Spread, FM, Depth, Shape)
 		voices: {
-			top: "Change the number of voices",
-			bottom: "This will change the number of voices generated"
+			top: "Voice Count",
+			bottom: "The number of voices generated!"
 		},
 		spread: {
-			top: "Change the spread of the voices",
-			bottom: "This will offset the pitch of each voice (in cents)"
+			top: "Voice Spread",
+			bottom: "The pitch offset of each voice (in cents)!"
 		},
 		fm: {
-			top: "Change the FM modulator frequency",
-			bottom: "This will change the frequency of the FM modulator"
+			top: "FM harmonicity",
+			bottom: "The ratio the between the carrier and modulator frequencies!"
 		},
 		fm_depth: {
-			top: "Change the FM modulator depth",
-			bottom: "This will change the amplitude of Frequency Modulation"
+			top: "FM depth",
+			bottom: "The amplitude of the modulator!"
 		},
 		fm_shape: {
-			top: "Change the FM modulator shape",
-			bottom: "This will change the shape of the FM modulator"
+			top: "FM shape",
+			bottom: "The shape of the modulator!"
 		},
 		// AM (AM, Shape)
 		am: {
-			top: "Change the AM modulator frequency",
-			bottom: "This will change the frequency of the AM modulator"
+			top: "AM harmonicity",
+			bottom: "The ratio the between the carrier and modulator frequencies!"
 		},
 		am_shape: {
-			top: "Change the AM modulator shape",
-			bottom: "This will change the shape of the AM modulator"
+			top: "AM shape",
+			bottom: "The shape of the modulator!"
 		},
 		// ADSR (Attack, Decay, Sustain, Release)
 		attack: {
-			top: "Change the attack time",
-			bottom: "This will change the time it takes for the envelope to reach its peak"
+			top: "Attack time",
+			bottom: "The time it takes for the envelope to reach its peak!"
 		},
 		decay: {
-			top: "Change the decay time",
-			bottom: "This will change the time it takes for the envelope to reach its sustain level"
+			top: "Decay time",
+			bottom: "The time it takes for the envelope to reach its sustain level!"
 		},
 		sustain: {
-			top: "Change the sustain level",
-			bottom: "This will change the level the envelope will sustain at"
+			top: "Sustain level",
+			bottom: "The level the envelope will sustain at!"
 		},
 		release: {
-			top: "Change the release time",
-			bottom: "This will change the time it takes for the envelope to return to silence"
+			top: "Release time",
+			bottom: "The time it takes for the envelope to return to silence!"
 		},
 		// Main (Octave, Detune, Volume, Shape)
 		octave: {
-			top: "Change the octave offset",
-			bottom: "This offsets the pitch of the oscillator, in octaves"
+			top: "Octave offset",
+			bottom: "The pitch offset of the oscillator, in octaves!"
 		},
 		semi: {
-			top: "Change the semitone offset",
-			bottom: "This offsets the pitch of the oscillator, in semitones"
+			top: "Semitone offset",
+			bottom: "The pitch offset of the oscillator, in semitones!"
 		},
 		volume: {
-			top: "Change the volume",
-			bottom: "This changes the volume of the oscillator"
+			top: "Volume",
+			bottom: "The amplitude of the oscillator!"
 		},
 		// Filter (Cutoff, Q/Gain, Rolloff, Type)
 		filter_cutoff: {
-			top: "Change the filter cutoff frequency",
-			bottom: "This changes the cutoff frequency of the filter"
+			top: "Filter cutoff frequency",
+			bottom: "The frequency at which the filter will begin to attenuate!"
 		},
-		filter_resonance: {
-			top: "Change the filter Q",
-			bottom: "This changes the resonance of the filter, be careful!"
-		},
+		filter_resonance: dynamicTooltips.FilterResonance,
 		// LFO (Rate, Min, Max, Shape)
 		lfo_rate: {
-			top: "Change the LFO rate",
-			bottom: "This changes the rate of the LFO"
+			top: "LFO rate",
+			bottom: "The speed of the LFO (in bars)!"
 		},
 		lfo_min: {
-			top: "Change the LFO minimum value",
-			bottom: "This changes the minimum value of the LFO"
+			top: "LFO minimum value",
+			bottom: "The lowest value the LFO will reach!"
 		},
 		lfo_max: {
-			top: "Change the LFO maximum value",
-			bottom: "This changes the maximum value of the LFO"
+			top: "LFO maximum value",
+			bottom: "The highest value the LFO will reach!"
 		},
 		// FX (Param 1, Param 2, Param 3, Param 4)
-		fx_param1: {
-			top: "Change the distortion intensity",
-			bottom: "This changes the intensity of the distortion"
-		},
-		fx_param2: {
-			top: "Change the distortion oversample",
-			bottom: "This changes the oversampling of the distortion algorithm"
-		},
-		fx_param3: {
-			top: "Change the distortion mix",
-			bottom: "This changes the wet level of the distortion effect"
-		},
-		fx_param4: {
-			top: "",
-			bottom: ""
-		}
+		fx_param1: dynamicTooltips[PRESET.FX.type].fx_param1,
+		fx_param2: dynamicTooltips[PRESET.FX.type].fx_param2,
+		fx_param3: dynamicTooltips[PRESET.FX.type].fx_param3,
+		fx_param4: dynamicTooltips[PRESET.FX.type].fx_param4,
 	},
 	"webaudio-slider": {
 		shape: {
-			top: "Change the shape",
-			bottom: "This changes the shape of the oscillator"
+			top: "Shape",
+			bottom: "The oscillator's waveform shape!"
 		},
 		filter_rolloff: {
-			top: "Change the filter rolloff",
-			bottom: "This changes the decibel rolloff of the filter curve"
+			top: "Filter rolloff",
+			bottom: "The decibel rolloff (slope) of the filter curve!"
 		},
 		filter_type: {
-			top: "Change the filter type",
-			bottom: "Choose between lowpass, highpass, bandpass, allpass, notch, lowshelf, and highshelf"
+			top: "Filter type",
+			bottom: "Choose between lowpass, highpass, bandpass, allpass, notch, lowshelf, and highshelf!"
 		},
 		lfo_shape: {
-			top: "Change the LFO shape",
-			bottom: "This changes the shape of the LFO"
+			top: "LFO shape",
+			bottom: "The LFO's waveform shape!"
 		},
 		arp_pattern: {
-			top: "Change the arp pattern",
-			bottom: "This changes the pattern of the arp"
+			top: "Arpeggiator pattern",
+			bottom: "The playback order of the notes!"
 		},
 		arp_speed: {
-			top: "Change the arp speed",
-			bottom: "This changes the speed of the arp"
+			top: "Arp speed",
+			bottom: "The playback speed of the notes (in bars)!"
 		},
 		master_octave: {
-			top: "Change the global octave modifier",
-			bottom: "This will change the octave of all oscillators"
+			top: "Global octave modifier",
+			bottom: "The octave offset for all oscillators!"
 		},
 	},
 	select: {
 		lfo_selector: {
-			top: "Select the LFO modulation target",
+			top: "LFO target selector",
 			bottom: "Choose between filter frequency and oscillator volume"
 		},
 		fx_selector: {
-			top: "Select an effect",
+			top: "Effect selector",
 			bottom: "Choose from a range of different effects!"
 		}
 	},
 	canvas: {
 		oscilloscope_a: {
 			top: "Oscilloscope A",
-			bottom: "This visualises the waveform of oscillator A!"
+			bottom: "This visualises the output of oscillator A!"
 		},
 		oscilloscope_b: {
 			top: "Oscilloscope B",
-			bottom: "This visualises the waveform of oscillator B!"
+			bottom: "This visualises the output of oscillator B!"
 		},
 		oscilloscope_c: {
 			top: "Oscilloscope C",
-			bottom: "This visualises the waveform of oscillator C!"
+			bottom: "This visualises the output of oscillator C!"
 		},
 		oscilloscope_lfo: {
 			top: "LFO Oscilloscope",
-			bottom: "This visualises the waveform of the LFO!"
+			bottom: "This visualises the output of the LFO!"
 		},
 		oscilloscope_master: {
 			top: "Master Oscilloscope",
-			bottom: "This visualises the waveform of the master output!"
+			bottom: "This visualises the master output (what you hear)!"
 		}
 	},
 	"webaudio-keyboard": {
 		keyboard: {
 			top: "GUI Keyboard",
-			bottom: "Click on the keys to play them, or use your keyboard!"
-		}
-	}
-}
-
-let fxTooltips = {
-	// FX Distortion (Intensity, Oversample, Mix)
-	Distortion: {
-		Intensity: {
-			top: "Change the distortion intensity",
-			bottom: "This changes the intensity of the distortion"
-		},
-		Oversample: {
-			top: "Change the distortion oversample",
-			bottom: "This changes the oversampling of the distortion algorithm"
-		},
-		Mix: {
-			top: "Change the distortion mix",
-			bottom: "This changes the wet level of the distortion effect"
-		}
-	},
-	// FX Chebyshev (Order, Mix)
-	Chebyshev: {
-		Order: {
-			top: "Change the Chebyshev distortion order",
-			bottom: "This changes the order of the Chebyshev distortion algorithm"
-		},
-		Mix: {
-			top: "Change the Chebyshev distortion mix",
-			bottom: "This changes the wet level of the Chebyshev distortion effect"
-		}
-	},
-	// FX Phaser (Frequency, Octaves, Q, Mix)
-	Phaser: {
-		Frequency: {
-			top: "Change the phaser frequency",
-			bottom: "This changes the frequency of the phaser"
-		},
-		Octaves: {
-			top: "Change the phaser octaves",
-			bottom: "This changes the number of octaves of the phaser"
-		},
-		Q: {
-			top: "Change the phaser Q",
-			bottom: "This changes the Q of the phaser"
-		},
-		Mix: {
-			top: "Change the phaser mix",
-			bottom: "This changes the wet level of the phaser effect"
-		}
-	},
-	// FX Tremolo (Frequency, Depth, Spread, Mix)
-	Tremolo: {
-		Frequency: {
-			top: "Change the tremolo frequency",
-			bottom: "This changes the frequency of the tremolo"
-		},
-		Depth: {
-			top: "Change the tremolo depth",
-			bottom: "This changes the depth of the tremolo"
-		},
-		Spread: {
-			top: "Change the tremolo spread",
-			bottom: "This changes the spread of the tremolo"
-		},
-		Mix: {
-			top: "Change the tremolo mix",
-			bottom: "This changes the wet level of the tremolo effect"
-		}
-	},
-	// FX Vibrato (Frequency, Depth, Type, Mix)
-	Vibrato: {
-		Frequency: {
-			top: "Change the vibrato frequency",
-			bottom: "This changes the frequency of the vibrato"
-		},
-		Depth: {
-			top: "Change the vibrato depth",
-			bottom: "This changes the depth of the vibrato"
-		},
-		Type: {
-			top: "Change the vibrato type",
-			bottom: "Choose between different oscillator shapes"
-		},
-		Mix: {
-			top: "Change the vibrato mix",
-			bottom: "This changes the wet level of the vibrato effect"
-		}
-	},
-	// FX Delay (Time, Feedback, Mix)
-	Delay: {
-		Time: {
-			top: "Change the delay time",
-			bottom: "This changes the time of the delay"
-		},
-		Feedback: {
-			top: "Change the delay feedback",
-			bottom: "This changes the feedback of the delay"
-		},
-		Mix: {
-			top: "Change the delay mix",
-			bottom: "This changes the wet level of the delay effect"
-		}
-	},
-	// FX Reverb (Decay, Pre-Delay, Mix)
-	Reverb: {
-		Decay: {
-			top: "Change the reverb decay",
-			bottom: "This changes the decay of the reverb"
-		},
-		PreDelay: {
-			top: "Change the reverb pre-delay",
-			bottom: "This changes the pre-delay of the reverb"
-		},
-		Mix: {
-			top: "Change the reverb mix",
-			bottom: "This changes the wet level of the reverb effect"
-		}
-	},
-	// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
-	PitchShift: {
-		Pitch: {
-			top: "Change the pitch shift pitch",
-			bottom: "This changes the pitch of the pitch shift"
-		},
-		Size: {
-			top: "Change the pitch shift window size",
-			bottom: "This changes the window size of the pitch shift"
-		},
-		Feedback: {
-			top: "Change the pitch shift feedback",
-			bottom: "This changes the feedback of the pitch shift"
-		},
-		Mix: {
-			top: "Change the pitch shift mix",
-			bottom: "This changes the wet level of the pitch shift effect"
-		}
-	},
-	// FX Frequency Shift (Frequency, Mix)
-	FreqShift: {
-		Frequency: {
-			top: "Change the frequency shift frequency",
-			bottom: "This changes the frequency of the frequency shift"
-		},
-		Mix: {
-			top: "Change the frequency shift mix",
-			bottom: "This changes the wet level of the frequency shift effect"
+			bottom: "Click on the keys to play them, or use your physical keyboard!"
 		}
 	}
 }

--- a/src/synth.js
+++ b/src/synth.js
@@ -3347,3 +3347,43 @@ consentButton.addEventListener("click", function () {
 	}
 	p5_canvas.classList.remove("hidden");
 })
+
+// -- TOOLTIPS -- //
+
+// Buttons (Settings, Presets, Random)
+
+// Switches (Groups, Arpeggiators, Sends, Record)
+
+// Controls - Master (BPM, Gain, Octave)
+
+// Controls - FM (Voices, Spread, FM, Depth, Shape)
+
+// Controls - ADSR (Attack, Decay, Sustain, Release)
+
+// Controls - Oscillator (Octave, Detune, Volume, Shape)
+
+// Controls - Filter (Cutoff, Q/Gain, Rolloff, Type)
+
+// Controls - LFO (Rate, Min, Max, Shape)
+
+// Selects - LFO (Filter Frequency, Oscillator Volume)
+
+// Controls - FX Distortion (Intensity, Oversample, Mix)
+
+// Controls - FX Chebyshev (Order, Mix)
+
+// Controls - FX Phaser (Frequency, Octaves, Q, Mix)
+
+// Controls - FX Tremolo (Frequency, Depth, Spread, Mix)
+
+// Controls - FX Vibrato (Frequency, Depth, Type, Mix)
+
+// Controls - FX Delay (Time, Feedback, Mix)
+
+// Controls - FX Reverb (Decay, Pre-Delay, Mix)
+
+// Controls - FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
+
+// Controls - FX Freq Shift (Frequency, Mix)
+
+// Controls - ARP (Pattern, Speed)

--- a/src/synth.js
+++ b/src/synth.js
@@ -847,10 +847,14 @@ function filterGroupUpdate(target) {
 	if (target === 5 || target === 6) {
 		// ...change the filter Q knob to gain knob
 		updateFilterKnob("filter_resonance", 1, 0, 24, 0.1, PRESET.FILTER.gain.toFixed(1), "Gain")
-		// Else if filter type is not lowshelf or highshelf...
+		tooltips["webaudio-knob"].filter_resonance.top = "Change the filter gain"
+		tooltips["webaudio-knob"].filter_resonance.bottom = "This changes the gain of the shelf filter"
+	// Else if filter type is not lowshelf or highshelf...
 	} else {
 		// ...change the filter gain knob to Q knob
 		updateFilterKnob("filter_resonance", 1, 1, 10, 0.1, PRESET.FILTER.Q, "Q")
+		tooltips["webaudio-knob"].filter_resonance.top = "Change the filter Q"
+		tooltips["webaudio-knob"].filter_resonance.bottom = "This changes the resonance of the filter, be careful!"
 	}
 }
 
@@ -952,6 +956,10 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 2, 1, 0, "Oversample")
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Distortion"]["Intensity"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Distortion"]["Oversample"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Distortion"]["Mix"]
 			break;
 		case "Chebyshev":
 			PRESET.FX.type = "Chebyshev"
@@ -961,6 +969,9 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(3, 0)
 			updateFxKnob(4, 0)
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Chebyshev"]["Order"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Chebyshev"]["Mix"]
 			break;
 		case "Phaser":
 			PRESET.FX.type = "Phaser"
@@ -970,6 +981,11 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 12, 0.1, 2, "Octaves")
 			updateFxKnob(3, 1, 0, 100, 0.1, 1, "Q")
 			updateFxKnob(4, 1, 0, 1, 0.1, 1, "Mix")
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Phaser"]["Frequency"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Phaser"]["Octaves"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Phaser"]["Q"]
+			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Phaser"]["Mix"]
 			break;
 		case "Tremolo":
 			PRESET.FX.type = "Tremolo"
@@ -979,6 +995,11 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 1, 0.01, 0, "Depth")
 			updateFxKnob(3, 1, 0, 100, 0.01, 0, "Spread")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Tremolo"]["Frequency"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Tremolo"]["Depth"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Tremolo"]["Spread"]
+			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Tremolo"]["Mix"]
 			break;
 		case "Vibrato":
 			PRESET.FX.type = "Vibrato"
@@ -988,6 +1009,11 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 1, 0.01, 0, "Depth")
 			updateFxKnob(3, 1, 0, 3, 1, 0, "Type", "['sine','triangle','sawtooth','square'][x]")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Vibrato"]["Frequency"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Vibrato"]["Depth"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Vibrato"]["Type"]
+			tooltips["webaudio-knob"].fx_param4 = fxTooltips["Vibrato"]["Mix"]
 			break;
 		case "Delay":
 			PRESET.FX.type = "Delay"
@@ -997,15 +1023,23 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 1, 0.01, 0.5, "Feedback")
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Delay"]["Time"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Delay"]["Feedback"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Delay"]["Mix"]
 			break;
 		case "Reverb":
 			PRESET.FX.type = "Reverb"
 			SELECTED_FX = FX_REVERB
 
 			updateFxKnob(1, 1, 0, 100, 1, 10, "Decay")
-			updateFxKnob(2, 1, 0, 5, 0.1, 0, "Pre-delay")
+			updateFxKnob(2, 1, 0, 5, 0.1, 0, "PreDelay")
 			updateFxKnob(3, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(4, 0)
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["Reverb"]["Decay"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["Reverb"]["Pre-delay"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["Reverb"]["Mix"]
 			break;
 		case "PitchShift":
 			PRESET.FX.type = "PitchShift"
@@ -1015,6 +1049,11 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0.01, 12, 0.01, 0.03, "Size")
 			updateFxKnob(3, 1, 0, 1, 0.01, 0.5, "Feedback")
 			updateFxKnob(4, 1, 0, 1, 0.1, 0.5, "Mix")
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["PitchShift"]["Pitch"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["PitchShift"]["Size"]
+			tooltips["webaudio-knob"].fx_param3 = fxTooltips["PitchShift"]["Feedback"]
+			tooltips["webaudio-knob"].fx_param4 = fxTooltips["PitchShift"]["Mix"]
 			break;
 		case "FreqShift":
 			PRESET.FX.type = "FreqShift"
@@ -1024,6 +1063,9 @@ function fxGroupUpdate(switchTarget){
 			updateFxKnob(2, 1, 0, 1, 0.1, 0.5, "Mix")
 			updateFxKnob(3, 0)
 			updateFxKnob(4, 0)
+
+			tooltips["webaudio-knob"].fx_param1 = fxTooltips["FreqShift"]["Frequency"]
+			tooltips["webaudio-knob"].fx_param2 = fxTooltips["FreqShift"]["Mix"]
 			break;
 		default:
 			console.log("Switch default: Nothing set for this case!")
@@ -3581,10 +3623,9 @@ let tooltips = {
 			top: "Change the filter cutoff frequency",
 			bottom: "This changes the cutoff frequency of the filter"
 		},
-		// TODO: Change this if using shelf filters
 		filter_resonance: {
-			top: "Change the filter Q (Resonance)",
-			bottom: "This changes the resonance of the filter"
+			top: "Change the filter Q",
+			bottom: "This changes the resonance of the filter, be careful!"
 		},
 		// LFO (Rate, Min, Max, Shape)
 		lfo_rate: {
@@ -3600,20 +3641,19 @@ let tooltips = {
 			bottom: "This changes the maximum value of the LFO"
 		},
 		// FX (Param 1, Param 2, Param 3, Param 4)
-		// TODO: Swap these out depending on the selected FX
-		fx_param_1: {
-			top: "",
-			bottom: ""
+		fx_param1: {
+			top: "Change the distortion intensity",
+			bottom: "This changes the intensity of the distortion"
 		},
-		fx_param_2: {
-			top: "",
-			bottom: ""
+		fx_param2: {
+			top: "Change the distortion oversample",
+			bottom: "This changes the oversampling of the distortion algorithm"
 		},
-		fx_param_3: {
-			top: "",
-			bottom: ""
+		fx_param3: {
+			top: "Change the distortion mix",
+			bottom: "This changes the wet level of the distortion effect"
 		},
-		fx_param_4: {
+		fx_param4: {
 			top: "",
 			bottom: ""
 		}
@@ -3690,7 +3730,7 @@ let tooltips = {
 
 let fxTooltips = {
 	// FX Distortion (Intensity, Oversample, Mix)
-	FX_DISTORTION: {
+	Distortion: {
 		Intensity: {
 			top: "Change the distortion intensity",
 			bottom: "This changes the intensity of the distortion"
@@ -3705,7 +3745,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Chebyshev (Order, Mix)
-	FX_CHEBYSHEV: {
+	Chebyshev: {
 		Order: {
 			top: "Change the Chebyshev distortion order",
 			bottom: "This changes the order of the Chebyshev distortion algorithm"
@@ -3716,7 +3756,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Phaser (Frequency, Octaves, Q, Mix)
-	FX_PHASER: {
+	Phaser: {
 		Frequency: {
 			top: "Change the phaser frequency",
 			bottom: "This changes the frequency of the phaser"
@@ -3735,7 +3775,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Tremolo (Frequency, Depth, Spread, Mix)
-	FX_TREMOLO: {
+	Tremolo: {
 		Frequency: {
 			top: "Change the tremolo frequency",
 			bottom: "This changes the frequency of the tremolo"
@@ -3754,7 +3794,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Vibrato (Frequency, Depth, Type, Mix)
-	FX_VIBRATO: {
+	Vibrato: {
 		Frequency: {
 			top: "Change the vibrato frequency",
 			bottom: "This changes the frequency of the vibrato"
@@ -3773,7 +3813,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Delay (Time, Feedback, Mix)
-	FX_DELAY: {
+	Delay: {
 		Time: {
 			top: "Change the delay time",
 			bottom: "This changes the time of the delay"
@@ -3788,7 +3828,7 @@ let fxTooltips = {
 		}
 	},
 	// FX Reverb (Decay, Pre-Delay, Mix)
-	FX_REVERB: {
+	Reverb: {
 		Decay: {
 			top: "Change the reverb decay",
 			bottom: "This changes the decay of the reverb"
@@ -3803,12 +3843,12 @@ let fxTooltips = {
 		}
 	},
 	// FX Pitch Shift (Pitch, Window Size, Feedback, Mix)
-	FX_PITCH_SHIFT: {
+	PitchShift: {
 		Pitch: {
 			top: "Change the pitch shift pitch",
 			bottom: "This changes the pitch of the pitch shift"
 		},
-		WindowSize: {
+		Size: {
 			top: "Change the pitch shift window size",
 			bottom: "This changes the window size of the pitch shift"
 		},
@@ -3821,8 +3861,8 @@ let fxTooltips = {
 			bottom: "This changes the wet level of the pitch shift effect"
 		}
 	},
-	// FX Freq Shift (Frequency, Mix)
-	FX_FREQ_SHIFT: {
+	// FX Frequency Shift (Frequency, Mix)
+	FreqShift: {
 		Frequency: {
 			top: "Change the frequency shift frequency",
 			bottom: "This changes the frequency of the frequency shift"


### PR DESCRIPTION
### Why?
- I realised it would likely be quite overwhelming if you had never used a synthesizer before and opened up MS24.
- I wanted to make my synth a little more beginner-friendly by adding tooltips, to explain each element of the synth.
- I could've gone about this a few ways, but I decided to go with a static approach, inspired by [Digitalis](https://aberrantdsp.com/plugins/digitalis/) by Aberrant DSP.
- This is because I couldn't figure out how to write a filter visualiser, leaving me with an annoyingly empty area in the synth...
- So I decided to kill two birds with one stone, placing tooltips in the filter visualiser, instead of an actual visualisation.

### What's New?
- Tooltips were added for every element on the main window of the synthesizer.
- Hovering over an element with the mouse pointer causes an explanation of that element to appear.
- Changing effects or other dynamic controls changes the tooltips given for relevant elements.

### What's Changed?
- FM control step sizes updated (only for oscillator A).
- Filter "Q" label changed to "Resonance".
- Changed Tremolo effect controls.
- Added some TODOs.